### PR TITLE
Integrate filters in search providers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,13 +52,13 @@ jobs:
 
         ckan -c test.ini db init
 
-        # Replace service URL in test.ini
+        # Replace service URL in provider ini files
         sed -i -e 's/localhost:8983/solr:8983/' test-solr.ini
         sed -i -e 's/localhost:9200/elasticsearch:9200/' test-elasticsearch.ini
 
-        ckan -c test.ini search init -p solr
+        ckan -c test-solr.ini search init -p solr
 
-        ckan -c test.ini search init -p elasticsearch
+        ckan -c test-elasticsearch.ini search init -p elasticsearch
 
     - name: Run search tests
       run: pytest --ckan-ini=test.ini --ignore=ckanext/search/tests/providers --cov=ckanext.search --disable-warnings ckanext/search/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,8 @@ jobs:
         ckan -c test.ini db init
 
         # Replace service URL in test.ini
-        sed -i -e 's/localhost:8983/solr:8983/' test.ini
-        sed -i -e 's/localhost:9200/elasticsearch:9200/' test.ini
+        sed -i -e 's/localhost:8983/solr:8983/' test-solr.ini
+        sed -i -e 's/localhost:9200/elasticsearch:9200/' test-elasticsearch.ini
 
         ckan -c test.ini search init -p solr
 
@@ -64,10 +64,8 @@ jobs:
       run: pytest --ckan-ini=test.ini --ignore=ckanext/search/tests/providers --cov=ckanext.search --disable-warnings ckanext/search/tests
 
     - name: Run Provider tests (Solr)
-      continue-on-error: true
       run: pytest --ckan-ini=test-solr.ini --cov=ckanext.search --disable-warnings ckanext/search/tests/providers
 
     - name: Run Provider tests (Elasticsearch)
-      continue-on-error: true
       run: pytest --ckan-ini=test-elasticsearch.ini --cov=ckanext.search --disable-warnings ckanext/search/tests/providers
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,9 +65,9 @@ jobs:
 
     - name: Run Provider tests (Solr)
       continue-on-error: true
-      run: pytest --ckan-ini=test.ini --search-provider=solr --cov=ckanext.search --disable-warnings ckanext/search/tests/providers
+      run: pytest --ckan-ini=test-solr.ini --cov=ckanext.search --disable-warnings ckanext/search/tests/providers
 
     - name: Run Provider tests (Elasticsearch)
       continue-on-error: true
-      run: pytest --ckan-ini=test.ini --search-provider=elasticsearch --cov=ckanext.search --disable-warnings ckanext/search/tests/providers
+      run: pytest --ckan-ini=test-elasticsearch.ini --cov=ckanext.search --disable-warnings ckanext/search/tests/providers
 

--- a/ckanext/search/index.py
+++ b/ckanext/search/index.py
@@ -48,6 +48,8 @@ def index_dataset_dict(dataset_dict: ActionResult.PackageShow) -> None:
     # TODO: handle resource fields
     search_data.pop("resources", None)
 
+    search_data["tags"] = [t["name"] for t in search_data.get("tags", [])]
+
     # Add search-specific fields
 
     search_data["entity_type"] = "dataset"

--- a/ckanext/search/interfaces.py
+++ b/ckanext/search/interfaces.py
@@ -40,6 +40,7 @@ class ISearchProvider(Interface):
             str, Any
         ],  # custom parameters this provider may process or ignore
         # TODO: config
+        search_schema: SearchSchema,
         lang: str,  # for text query language stemming e.g. 'de'
         return_ids: bool = False,  # True: return records as ids (may increase maximum record limit)
         return_entity_types: bool = False,  # True: wrap records with {'entity_type': et, 'data': record} objects

--- a/ckanext/search/logic/actions.py
+++ b/ckanext/search/logic/actions.py
@@ -12,6 +12,7 @@ from ckan.plugins.toolkit import (
 )
 from ckan.types import Context, DataDict
 from ckanext.search.interfaces import ISearchProvider, ISearchFeature
+from ckanext.search.schema import get_search_schema
 from ckanext.search.logic.schema import default_search_query_schema
 from ckanext.search.filters import FilterOp
 
@@ -100,13 +101,17 @@ def search(context: Context, data_dict: DataDict):
         else:
             query_dict["filters"] = perm_labels_filter_op
 
+    search_schema = get_search_schema()
+    query_dict["search_schema"] = search_schema
     search_backend = config["ckan.search.search_backend"]
     result = {}
     for plugin in PluginImplementations(ISearchProvider):
         if plugin.id == search_backend:
             result = plugin.search_query(**query_dict)
             break
+    query_dict.pop("search_schema")
 
+    # TODO: pass search_schema here
     # Allow search extensions to modify the query results
     for plugin in PluginImplementations(ISearchFeature):
         plugin.after_query(result, query_dict)

--- a/ckanext/search/logic/schema.py
+++ b/ckanext/search/logic/schema.py
@@ -60,7 +60,7 @@ def default_search_query_schema(
         ],
         "sort": [ignore_missing, json_list_or_string],
         # TODO: index value based ordering
-        "start": [ignore_missing, ignore_empty, natural_number_validator],
+        "start": [default(0), natural_number_validator],
         "filters": [
             ignore_missing,
             convert_to_json_if_string,

--- a/ckanext/search/providers/es.py
+++ b/ckanext/search/providers/es.py
@@ -8,6 +8,7 @@ from ckan.plugins.toolkit import config
 from elasticsearch import Elasticsearch
 
 from ckanext.search.interfaces import ISearchProvider, SearchResults, SearchSchema
+from ckanext.search.filters import FilterOp
 
 log = logging.getLogger(__name__)
 
@@ -95,7 +96,7 @@ class ElasticSearchProvider(SingletonPlugin):
     def search_query(
         self,
         q: str,
-        filters: dict[str, str | list[str]],
+        filters: FilterOp,
         sort: list[list[str]],
         additional_params: dict[str, Any],
         lang: str,
@@ -107,15 +108,32 @@ class ElasticSearchProvider(SingletonPlugin):
         start: int = 0,
     ) -> Optional[SearchResults]:
 
-        # Transform generic search params to Elastic Search query params
+        es_params = {"size": limit, "from": start}
 
-        # TODO: Use ES query DSL
-        es_params = {"q": q}
+        # Translate q param to ES Query DSL
+        if q and q in ("*", "*:*"):
+            q_dsl = {"match_all": {}}
+        elif q:
+            q_dsl = {"simple_query_string": {"query": q}}
+        else:
+            q_dsl = None
+
+        # Transform generic search params to ES Query DSL
+        filters_dsl = self._filterop_to_es_query(filters, search_schema)
+
+        if q_dsl and filters_dsl:
+            es_params["query"] = {"bool": {"must": [q_dsl, filters_dsl]}}
+        elif q_dsl:
+            es_params["query"] = q_dsl
+        elif filters_dsl:
+            es_params["query"] = filters_dsl
+        else:
+            es_params["query"] = {"match_all": {}}
 
         client = self.get_client()
 
         # TODO: error handling
-        es_response = client.search(**es_params)
+        es_response = client.search(index=self._index_name, **es_params)
 
         items = []
         for doc in es_response["hits"]["hits"]:
@@ -125,13 +143,86 @@ class ElasticSearchProvider(SingletonPlugin):
 
         return {"count": len(items), "results": items, "facets": {}}
 
+    def _filterop_to_es_query(
+        self, filter_op: FilterOp, search_schema: SearchSchema
+    ) -> Optional[dict]:
+        """
+        Convert a FilterOp object to ElasticSearch DSL query.
+        Returns a dict representing the ES query DSL.
+        """
+        if not filter_op:
+            return None
+
+        if not isinstance(filter_op, FilterOp):
+            raise ValueError("A FilterOp object is needed")
+
+        if filter_op.op in ["$and", "$or"]:
+            if not isinstance(filter_op.value, list):
+                return None
+
+            sub_queries = []
+            for sub_op in filter_op.value:
+                if isinstance(sub_op, FilterOp):
+                    sub_query = self._filterop_to_es_query(sub_op, search_schema)
+                    if sub_query:
+                        sub_queries.append(sub_query)
+
+            if not sub_queries:
+                return None
+
+            if len(sub_queries) == 1:
+                return sub_queries[0]
+
+            if filter_op.op == "$and":
+                return {"bool": {"must": sub_queries}}
+            else:  # $or
+                return {"bool": {"should": sub_queries, "minimum_should_match": 1}}
+
+        else:
+            # Handle field operators
+            field_name = filter_op.field
+            op = filter_op.op
+            value = filter_op.value
+
+            if not field_name:
+                return None
+
+            field_type = self._get_field_type(field_name, search_schema)
+
+            if op == "eq":
+                return {"term": {field_name: value}}
+            elif op == "gt":
+                return {"range": {field_name: {"gt": value}}}
+            elif op == "gte":
+                return {"range": {field_name: {"gte": value}}}
+            elif op == "lt":
+                return {"range": {field_name: {"lt": value}}}
+            elif op == "lte":
+                return {"range": {field_name: {"lte": value}}}
+            elif op == "in" and isinstance(value, list) and value:
+                return {"terms": {field_name: value}}
+            else:
+                # Unknown operator, assume equality for now
+                return {"term": {field_name: value}}
+
+    def _get_field_type(
+        self, field_name: str, search_schema: SearchSchema
+    ) -> Optional[str]:
+        """Get field type from search schema."""
+        if field_info := search_schema.get("fields", {}).get(field_name):
+            return field_info.get("type")
+        return None
+
     def clear_index(self) -> None:
 
         client = self.get_client()
         # TODO: review bulk, versions, slices, etc
         # TODO: wait for completion
         client.delete_by_query(
-            q="*:*", index=self._index_name, wait_for_completion=True
+            index=self._index_name,
+            body={"query": {"match_all": {}}},
+            conflicts="proceed",
+            wait_for_completion=True,
         )
         log.info("Cleared all documents in the search index")
 

--- a/ckanext/search/providers/es.py
+++ b/ckanext/search/providers/es.py
@@ -199,8 +199,11 @@ class ElasticSearchProvider(SingletonPlugin):
                 return {"range": {field_name: {"lt": value}}}
             elif op == "lte":
                 return {"range": {field_name: {"lte": value}}}
-            elif op == "in" and isinstance(value, list) and value:
-                return {"terms": {field_name: value}}
+            elif op == "in":
+                if isinstance(value, list) and value:
+                    return {"terms": {field_name: value}}
+                else:
+                    return None
             else:
                 # Unknown operator, assume equality for now
                 return {"term": {field_name: value}}

--- a/ckanext/search/providers/es.py
+++ b/ckanext/search/providers/es.py
@@ -99,6 +99,7 @@ class ElasticSearchProvider(SingletonPlugin):
         sort: list[list[str]],
         additional_params: dict[str, Any],
         lang: str,
+        search_schema: SearchSchema,
         return_ids: bool = False,
         return_entity_types: bool = False,
         return_facets: bool = False,

--- a/ckanext/search/providers/solr.py
+++ b/ckanext/search/providers/solr.py
@@ -439,15 +439,7 @@ class SolrSearchProvider(SingletonPlugin):
                 "lte": "{field_name}:[* TO {value}]",
             }
 
-            if op == "in" and isinstance(value, list) and value:
-                return [
-                    " OR ".join(
-                        f"{field_name}:{self._process_value(v, field_type)}"
-                        for v in value
-                    )
-                ]
-
-            elif op in op_templates:
+            if op in op_templates:
                 return [
                     op_templates[op].format(
                         field_name=field_name,
@@ -456,6 +448,16 @@ class SolrSearchProvider(SingletonPlugin):
                         ),
                     )
                 ]
+            elif op == "in":
+                if isinstance(value, list) and value:
+                    return [
+                        " OR ".join(
+                            f"{field_name}:{self._process_value(v, field_type)}"
+                            for v in value
+                        )
+                    ]
+                else:
+                    return []
             else:
                 # Unknown operator, assume equality for now
                 # TODO: how to handle custom ones?

--- a/ckanext/search/providers/solr.py
+++ b/ckanext/search/providers/solr.py
@@ -11,6 +11,7 @@ from ckan.plugins import SingletonPlugin, implements
 from ckan.plugins.toolkit import config, get_validator
 from ckan.types import Schema
 from ckanext.search.interfaces import ISearchProvider, SearchResults, SearchSchema
+from ckanext.search.filters import FilterOp
 
 log = logging.getLogger(__name__)
 
@@ -310,10 +311,11 @@ class SolrSearchProvider(SingletonPlugin):
     def search_query(
         self,
         q: str,
-        filters: dict[str, str | list[str]],
+        filters: FilterOp,
         sort: list[list[str]],
         additional_params: dict[str, Any],
         lang: str,
+        search_schema: SearchSchema,
         return_ids: bool = False,
         return_entity_types: bool = False,
         return_facets: bool = False,
@@ -338,10 +340,12 @@ class SolrSearchProvider(SingletonPlugin):
             "fq": fq,
         }
 
+        solr_params["fq"] = self._filterop_to_solr_fq(filters, search_schema)
+
         # TODO: perm labels for arbitrary entities
 
-        # TODO: Migrate to FilterOp
-        #if "permission_labels" in filters:
+        # TODO: handle perm labels
+        # if "permission_labels" in filters:
         #    perms_conditions = (
         #        "permission_labels:("
         #        + " OR ".join(solr_literal(p) for p in filters["permission_labels"])
@@ -383,6 +387,109 @@ class SolrSearchProvider(SingletonPlugin):
         except pysolr.SolrError as e:
             # TODO:
             raise e
+
+    def _filterop_to_solr_fq(
+        self, filter_op: FilterOp, search_schema: SearchSchema
+    ) -> list[str]:
+        """
+        Convert a FilterOp object to Solr filter query strings.
+        Returns a list of filter query strings.
+        """
+        if not filter_op:
+            return []
+
+        if not isinstance(filter_op, FilterOp):
+            raise ValueError("A FilterOp object is needed")
+
+        if filter_op.op in ["$and", "$or"]:
+
+            if not isinstance(filter_op.value, list):
+                return []
+
+            sub_filters = []
+            for sub_op in filter_op.value:
+                if isinstance(sub_op, FilterOp):
+                    sub_filters.extend(self._filterop_to_solr_fq(sub_op, search_schema))
+
+            if not sub_filters:
+                return []
+
+            if len(sub_filters) == 1:
+                return sub_filters
+
+            operator = "AND" if filter_op.op == "$and" else "OR"
+            return [f" {operator} ".join(f"({f})" for f in sub_filters)]
+
+        else:
+            # Handle field operators
+            field_name = filter_op.field
+            op = filter_op.op
+            value = filter_op.value
+
+            if not field_name:
+                return []
+
+            field_type = self._get_field_type(field_name, search_schema)
+
+            op_templates = {
+                "eq": "{field_name}:{value}",
+                "gt": "{field_name}:{{{value} TO *}}",
+                "gte": "{field_name}:[{value} TO *]",
+                "lt": "{field_name}:{{* TO {value}}}",
+                "lte": "{field_name}:[* TO {value}]",
+            }
+
+            if op == "in" and isinstance(value, list) and value:
+                return [
+                    " OR ".join(
+                        f"{field_name}:{self._process_value(v, field_type)}"
+                        for v in value
+                    )
+                ]
+
+            elif op in op_templates:
+                return [
+                    op_templates[op].format(
+                        field_name=field_name,
+                        value=self._process_value(
+                            value, field_type, range_query=op != "eq"
+                        ),
+                    )
+                ]
+            else:
+                # Unknown operator, assume equality for now
+                # TODO: how to handle custom ones?
+                return [f"{field_name}:{self._process_value(value, field_type)}"]
+
+    def _process_value(
+        self, value: Any, field_type: Optional[str] = None, range_query: bool = False
+    ) -> str:
+        value = self._escape_value(str(value))
+        if field_type:
+            # TODO: review more types need to be quoted
+            if field_type in ("text", "string"):
+                value = self._quote_value(value)
+            elif field_type == "date" and not range_query:
+                value = self._quote_value(value)
+        else:
+            value = self._quote_value(value)
+
+        return value
+
+    def _get_field_type(
+        self, field_name: str, search_schema: SearchSchema
+    ) -> Optional[str]:
+
+        if field_info := search_schema.get("fields", {}).get(field_name):
+            return field_info.get("type")
+
+    def _quote_value(self, value: str) -> str:
+        # Wrap value in double quotes
+        return f'"{value}"'
+
+    def _escape_value(self, value: str) -> str:
+        # Escape quotes
+        return value.replace('"', '\\"')
 
     # Backend methods
 

--- a/ckanext/search/schema.py
+++ b/ckanext/search/schema.py
@@ -42,6 +42,7 @@ DEFAULT_DATASET_SEARCH_SCHEMA: SearchSchema = {
         "name": {"type": "text"},
         "title": {"type": "text"},
         "notes": {"type": "text"},
+        "version": {"type": "text"},
         "tags": {"type": "string", "multiple": True},
         "groups": {"type": "string", "multiple": True},
         "organization": {"type": "string"},

--- a/ckanext/search/tests/conftest.py
+++ b/ckanext/search/tests/conftest.py
@@ -2,6 +2,8 @@ import pytest
 
 from ckan.plugins.toolkit import config
 
+from ckanext.search.index import clear_index
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -15,6 +17,7 @@ def pytest_addoption(parser):
 def search_providers():
     pass
 
+
 def pytest_runtest_setup(item):
 
     if "search_providers" in item.fixturenames and item.config.option.search_provider:
@@ -23,3 +26,10 @@ def pytest_runtest_setup(item):
                 "ckan.search.search_backend", item.config.option.search_provider
             )
         )
+
+
+@pytest.fixture
+def clean_search_index():
+    clear_index()
+    yield
+    clear_index()

--- a/ckanext/search/tests/conftest.py
+++ b/ckanext/search/tests/conftest.py
@@ -1,31 +1,6 @@
 import pytest
 
-from ckan.plugins.toolkit import config
-
 from ckanext.search.index import clear_index
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--search-provider",
-        default=None,  # If none provided, use the one in test.ini or the default one
-        help="Search provider to run the tests against",
-    )
-
-
-@pytest.fixture
-def search_providers():
-    pass
-
-
-def pytest_runtest_setup(item):
-
-    if "search_providers" in item.fixturenames and item.config.option.search_provider:
-        item.add_marker(
-            pytest.mark.ckan_config(
-                "ckan.search.search_backend", item.config.option.search_provider
-            )
-        )
 
 
 @pytest.fixture

--- a/ckanext/search/tests/elasticsearch/test_es_provider.py
+++ b/ckanext/search/tests/elasticsearch/test_es_provider.py
@@ -1,0 +1,264 @@
+import datetime
+
+import pytest
+from ckan.plugins.toolkit import config
+
+from ckanext.search.filters import FilterOp
+from ckanext.search.interfaces import SearchSchema
+from ckanext.search.providers.es import ElasticSearchProvider
+
+
+pytestmark = pytest.mark.skipif(
+    config.get("ckan.search.search_backend") != "elasticsearch",
+    reason="These tests are ElasticSearch specific",
+)
+
+
+SEARCH_SCHEMA: SearchSchema = {
+    "version": 1,
+    "fields": {
+        "some_text_field": {"type": "text"},
+        "some_numeric_field": {
+            "type": "number"  # TODO: still not defined (probably need int,...)
+        },
+        "some_date_field": {"type": "date"},
+    },
+}
+
+
+@pytest.fixture
+def esp():
+
+    return ElasticSearchProvider()
+
+
+@pytest.mark.parametrize(
+    "filters,result",
+    [
+        (
+            FilterOp(field="some_text_field", op="eq", value="some_value"),
+            {"term": {"some_text_field": "some_value"}},
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="eq", value=2),
+            {"term": {"some_numeric_field": 2}},
+        ),
+    ],
+)
+def test_filters_builtin_operations_eq(esp, filters, result):
+
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_builtin_operations_eq_date(esp):
+    now = datetime.datetime.now().isoformat()
+    filters = FilterOp(
+        field="some_date_field",
+        op="eq",
+        value=now,
+    )
+
+    result = {"term": {"some_date_field": now}}
+
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+@pytest.mark.parametrize(
+    "filters,result",
+    [
+        (
+            FilterOp(field="some_numeric_field", op="gt", value=5),
+            {"range": {"some_numeric_field": {"gt": 5}}},
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="gte", value=5),
+            {"range": {"some_numeric_field": {"gte": 5}}},
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="lt", value=5),
+            {"range": {"some_numeric_field": {"lt": 5}}},
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="lte", value=5),
+            {"range": {"some_numeric_field": {"lte": 5}}},
+        ),
+    ],
+)
+def test_filters_builtin_operations_ranges_numbers(esp, filters, result):
+
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+@pytest.mark.parametrize(
+    "filters,result",
+    [
+        (
+            FilterOp(field="some_date_field", op="gt", value="2025-06-06T00:00:00Z"),
+            {"range": {"some_date_field": {"gt": "2025-06-06T00:00:00Z"}}},
+        ),
+        (
+            FilterOp(field="some_date_field", op="gte", value="2025-06-06T00:00:00Z"),
+            {"range": {"some_date_field": {"gte": "2025-06-06T00:00:00Z"}}},
+        ),
+        (
+            FilterOp(field="some_date_field", op="lt", value="2025-06-06T00:00:00Z"),
+            {"range": {"some_date_field": {"lt": "2025-06-06T00:00:00Z"}}},
+        ),
+        (
+            FilterOp(field="some_date_field", op="lte", value="2025-06-06T00:00:00Z"),
+            {"range": {"some_date_field": {"lte": "2025-06-06T00:00:00Z"}}},
+        ),
+    ],
+)
+def test_filters_builtin_operations_ranges_dates(esp, filters, result):
+
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_unknown_field_returns_term_query(esp):
+    filters = FilterOp(
+        field="unknown_field",
+        op="eq",
+        value="some_value",
+    )
+    result = {"term": {"unknown_field": "some_value"}}
+
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_in_operation(esp):
+    filters = FilterOp(
+        field="some_text_field",
+        op="in",
+        value=["value1", "value2", "value3"],
+    )
+
+    result = {"terms": {"some_text_field": ["value1", "value2", "value3"]}}
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_in_operation_empty_list(esp):
+    filters = FilterOp(
+        field="some_text_field",
+        op="in",
+        value=[],
+    )
+
+    result = esp._filterop_to_es_query(filters, SEARCH_SCHEMA)
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "filters,result",
+    [
+        (
+            FilterOp(field="some_text_field", op="eq", value='some "quoted" value'),
+            {"term": {"some_text_field": 'some "quoted" value'}},
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="eq", value='some "quoted" value'),
+            {"term": {"some_numeric_field": 'some "quoted" value'}},
+        ),
+        (
+            FilterOp(field="some_date_field", op="eq", value='some "quoted" value'),
+            {"term": {"some_date_field": 'some "quoted" value'}},
+        ),
+    ],
+)
+def test_filters_quotes_are_preserved(esp, filters, result):
+
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_basic_or(esp):
+
+    filters = FilterOp(
+        field=None,
+        op="$or",
+        value=[
+            FilterOp(field="some_text_field", op="eq", value="some_value1"),
+            FilterOp(field="some_text_field", op="eq", value="some_value2"),
+        ],
+    )
+
+    result = {
+        "bool": {
+            "should": [
+                {"term": {"some_text_field": "some_value1"}},
+                {"term": {"some_text_field": "some_value2"}},
+            ],
+            "minimum_should_match": 1,
+        }
+    }
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_basic_and(esp):
+
+    filters = FilterOp(
+        field=None,
+        op="$and",
+        value=[
+            FilterOp(field="some_text_field", op="eq", value="some_value1"),
+            FilterOp(field="some_numeric_field", op="lte", value=10),
+        ],
+    )
+
+    result = {
+        "bool": {
+            "must": [
+                {"term": {"some_text_field": "some_value1"}},
+                {"range": {"some_numeric_field": {"lte": 10}}},
+            ]
+        }
+    }
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_permission_labels(esp):
+    labels = ["creator-xxx", "member-yyy", "collaborator-zzz"]
+    perm_labels_filter_op = FilterOp(field="permission_labels", op="in", value=labels)
+
+    filters = FilterOp(
+        field=None,
+        op="$and",
+        value=[
+            FilterOp(
+                field=None,
+                op="$and",
+                value=[
+                    FilterOp(field="some_text_field", op="eq", value="some_value1"),
+                    FilterOp(field="some_numeric_field", op="lte", value=10),
+                ],
+            ),
+            perm_labels_filter_op,
+        ],
+    )
+
+    result = {
+        "bool": {
+            "must": [
+                {
+                    "bool": {
+                        "must": [
+                            {"term": {"some_text_field": "some_value1"}},
+                            {"range": {"some_numeric_field": {"lte": 10}}},
+                        ]
+                    }
+                },
+                {"terms": {"permission_labels": labels}},
+            ]
+        }
+    }
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_unknown_operator_defaults_to_term(esp):
+    filters = FilterOp(
+        field="some_text_field",
+        op="unknown_op",
+        value="some_value",
+    )
+
+    result = {"term": {"some_text_field": "some_value"}}
+    assert esp._filterop_to_es_query(filters, SEARCH_SCHEMA) == result

--- a/ckanext/search/tests/factories.py
+++ b/ckanext/search/tests/factories.py
@@ -1,3 +1,5 @@
+from ckan import model
+
 from ckan.tests import factories as core_factories
 
 from ckanext.search import index
@@ -23,6 +25,8 @@ class CKANIndexedOnlyFactory(core_factories.CKANFactory):
 
         if cls.indexer:
             cls.indexer(result)
+
+        model.Session.rollback()
 
         return result
 

--- a/ckanext/search/tests/providers/test_query.py
+++ b/ckanext/search/tests/providers/test_query.py
@@ -1,0 +1,56 @@
+import pytest
+from ckanext.search.logic.actions import search as search_action
+from ckanext.search.tests import factories
+
+pytestmark = pytest.mark.usefixtures(
+    "with_plugins", "search_providers", "clean_search_index"
+)
+
+
+def search(**kwargs):
+
+    context = {"ignore_auth": True}
+    return search_action(context, kwargs)
+
+
+@pytest.mark.parametrize(
+    "field_name,field_value",
+    [
+        ("name", "walrus-data"),
+        ("title", "Walrus data"),
+        ("notes", "Some data about a walrus"),
+    ],
+)
+def test_search_dataset_combined_field(field_name, field_value):
+
+    dataset = factories.IndexedDataset(**{field_name: field_value})
+
+    result = search(q="walrus")
+
+    assert result["count"] == 1
+    assert result["results"][0]["id"] == dataset["id"]
+    assert result["results"][0][field_name] == field_value
+
+
+# TODO: test stemming English
+
+# TODO: test stemming other languages
+
+
+@pytest.mark.parametrize(
+    "field_name,field_value",
+    [
+        ("name", "walrus-org"),
+        ("title", "Walrus org"),
+        ("description", "Some org about a walrus"),
+    ],
+)
+def test_search_organization_combined_field(field_name, field_value):
+
+    organization = factories.IndexedOrganization(**{field_name: field_value})
+
+    result = search(q="walrus")
+
+    assert result["count"] == 1
+    assert result["results"][0]["id"] == organization["id"]
+    assert result["results"][0][field_name] == field_value

--- a/ckanext/search/tests/providers/test_query.py
+++ b/ckanext/search/tests/providers/test_query.py
@@ -1,10 +1,16 @@
 import pytest
+
+from ckan.plugins.toolkit import config
 from ckanext.search.logic.actions import search as search_action
 from ckanext.search.tests import factories
 
-pytestmark = pytest.mark.usefixtures(
-    "with_plugins", "clean_search_index"
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not config.get("ckan.search.search_backend"),
+        reason="No search provided defined",
+    ),
+    pytest.mark.usefixtures("with_plugins", "clean_search_index"),
+]
 
 
 def search(**kwargs):

--- a/ckanext/search/tests/providers/test_query.py
+++ b/ckanext/search/tests/providers/test_query.py
@@ -3,7 +3,7 @@ from ckanext.search.logic.actions import search as search_action
 from ckanext.search.tests import factories
 
 pytestmark = pytest.mark.usefixtures(
-    "with_plugins", "search_providers", "clean_search_index"
+    "with_plugins", "clean_search_index"
 )
 
 

--- a/ckanext/search/tests/providers/test_query_filters.py
+++ b/ckanext/search/tests/providers/test_query_filters.py
@@ -49,7 +49,7 @@ def index_for_filters_tests():
     )
 
 
-@pytest.mark.usefixtures("with_plugins", "search_providers", "index_for_filters_tests")
+@pytest.mark.usefixtures("with_plugins", "index_for_filters_tests")
 @pytest.mark.parametrize(
     "filters,names",
     [

--- a/ckanext/search/tests/providers/test_query_filters.py
+++ b/ckanext/search/tests/providers/test_query_filters.py
@@ -1,8 +1,15 @@
 import pytest
 
+from ckan.plugins.toolkit import config
 from ckanext.search.index import clear_index
 from ckanext.search.logic.actions import search as search_action
 from ckanext.search.tests import factories
+
+
+pytestmark = pytest.mark.skipif(
+    not config.get("ckan.search.search_backend"),
+    reason="No search provided defined",
+)
 
 
 def search(**kwargs):

--- a/ckanext/search/tests/providers/test_search.py
+++ b/ckanext/search/tests/providers/test_search.py
@@ -3,13 +3,13 @@ from ckanext.search.logic.actions import search as search_action
 from ckanext.search.index import clear_index
 from ckanext.search.tests import factories
 
-pytestmark = pytest.mark.usefixtures(
-    "with_plugins", "clean_search_index", "search_providers"
-)
+pytestmark = pytest.mark.usefixtures("with_plugins", "search_providers")
 
 
 @pytest.fixture
 def clean_search_index():
+    clear_index()
+    yield
     clear_index()
 
 
@@ -19,6 +19,7 @@ def search(**kwargs):
     return search_action(context, kwargs)
 
 
+@pytest.mark.usefixtures("clean_search_index")
 @pytest.mark.parametrize(
     "field_name,field_value",
     [
@@ -43,6 +44,7 @@ def test_search_dataset_combined_field(field_name, field_value):
 # TODO: test stemming other languages
 
 
+@pytest.mark.usefixtures("clean_search_index")
 @pytest.mark.parametrize(
     "field_name,field_value",
     [
@@ -60,3 +62,130 @@ def test_search_organization_combined_field(field_name, field_value):
     assert result["count"] == 1
     assert result["results"][0]["id"] == organization["id"]
     assert result["results"][0][field_name] == field_value
+
+
+@pytest.fixture(scope="session")
+def index_for_filters_tests():
+
+    factories.IndexedDataset(
+        name="dataset-cats",
+        title="A dataset about cats",
+        tags=[{"name": "cats"}, {"name": "animal"}],
+        metadata_modified="2025-03-01T00:00:00",
+        version="1",
+    )
+
+    factories.IndexedDataset(
+        name="dataset-dogs",
+        title="A dataset about dogs",
+        tags=[{"name": "dogs"}, {"name": "animal"}],
+        metadata_modified="2025-04-01T00:00:00",
+        version="2",
+    )
+
+    factories.IndexedDataset(
+        name="dataset-snakes",
+        title="A dataset about snakes",
+        tags=[{"name": "snakes"}, {"name": "animal"}],
+        metadata_modified="2025-04-01T00:00:00",
+        version="3",
+    )
+
+    factories.IndexedDataset(
+        name="dataset-oaks",
+        title="A dataset about oaks",
+        tags=[{"name": "oaks"}, {"name": "plant"}],
+        metadata_modified="2025-02-01T00:00:00",
+        version="1",
+    )
+
+
+@pytest.mark.usefixtures("index_for_filters_tests")
+@pytest.mark.parametrize(
+    "filters,names",
+    [
+        (None, ["dataset-cats", "dataset-dogs", "dataset-oaks", "dataset-snakes"]),
+        # Single field shorthand
+        ({"tags": "cats"}, ["dataset-cats"]),
+        # Single field
+        ({"tags": {"eq": "cats"}}, ["dataset-cats"]),
+        # OR shorthand
+        # (Needs to be passed as string otherwise Navl won't understand it)
+        (
+            '[{"tags": "cats"}, {"tags": "snakes"}]',
+            ["dataset-cats", "dataset-snakes"],
+        ),
+        # OR
+        (
+            {"$or": [{"tags": "dogs"}, {"tags": "snakes"}]},
+            ["dataset-dogs", "dataset-snakes"],
+        ),
+        # AND shortand
+        (
+            {"tags": "animal", "version": "2"},
+            ["dataset-dogs"],
+        ),
+        # AND
+        (
+            {"$and": [{"tags": "animal"}, {"version": "2"}]},
+            ["dataset-dogs"],
+        ),
+        # Nested
+        (
+            {
+                "$or": [
+                    {"tags": "dogs"},
+                    {"$and": [{"tags": "animal"}, {"version": "1"}]},
+                ]
+            },
+            ["dataset-cats", "dataset-dogs"],
+        ),
+        # IN shorthand
+        (
+            {"version": ["2", "3"]},
+            ["dataset-dogs", "dataset-snakes"],
+        ),
+        # IN
+        (
+            {"version": {"in": ["2", "3"]}},
+            ["dataset-dogs", "dataset-snakes"],
+        ),
+        # Ranges
+        (
+            {"metadata_modified": {"gt": "2025-03-01T00:00:00Z"}},
+            ["dataset-dogs", "dataset-snakes"],
+        ),
+        (
+            {"metadata_modified": {"gte": "2025-03-01T00:00:00Z"}},
+            ["dataset-cats", "dataset-dogs", "dataset-snakes"],
+        ),
+        (
+            {
+                "metadata_modified": {
+                    "gte": "2025-02-01T00:00:00Z",
+                    "lte": "2025-03-01T00:00:00Z",
+                }
+            },
+            ["dataset-cats", "dataset-oaks"],
+        ),
+        (
+            {"version": {"lt": "2"}},
+            ["dataset-cats", "dataset-oaks"],
+        ),
+        (
+            {"version": {"lte": "2"}},
+            ["dataset-cats", "dataset-dogs", "dataset-oaks"],
+        ),
+        (
+            {"version": {"gt": "1", "lt": "3"}},
+            ["dataset-dogs"],
+        ),
+    ],
+)
+def test_search_filters(index_for_filters_tests, filters, names):
+
+    result = search(q="*", filters=filters)
+
+    assert result["count"] == len(names)
+    if names:
+        assert sorted([d["name"] for d in result["results"]]) == names

--- a/ckanext/search/tests/solr/test_solr_provider.py
+++ b/ckanext/search/tests/solr/test_solr_provider.py
@@ -43,10 +43,6 @@ def ssp():
             FilterOp(field="some_numeric_field", op="eq", value=2),
             ["some_numeric_field:2"],
         ),
-        (
-            FilterOp(field="some_numeric_field", op="eq", value="2"),
-            ["some_numeric_field:2"],
-        ),
     ],
 )
 def test_filters_builtin_operations_eq(ssp, filters, result):
@@ -118,6 +114,32 @@ def test_filters_builtin_operations_ranges_numbers(ssp, filters, result):
 def test_filters_builtin_operations_ranges_dates(ssp, filters, result):
 
     assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_in_operation(ssp):
+    filters = FilterOp(
+        field="some_text_field",
+        op="in",
+        value=["value1", "value2", "value3"],
+    )
+
+    result = [
+        'some_text_field:"value1" OR '
+        'some_text_field:"value2" OR '
+        'some_text_field:"value3"'
+    ]
+    assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_in_operation_empty_list(ssp):
+    filters = FilterOp(
+        field="some_text_field",
+        op="in",
+        value=[],
+    )
+
+    result = ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA)
+    assert result == []
 
 
 def test_filters_unknown_field_is_quoted(ssp):
@@ -209,4 +231,15 @@ def test_filters_permission_labels(ssp):
         'permission_labels:"member-yyy" OR '
         'permission_labels:"collaborator-zzz")'
     ]
+    assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_unknown_operator_defaults_to_equality(ssp):
+    filters = FilterOp(
+        field="some_text_field",
+        op="unknown_op",
+        value="some_value",
+    )
+
+    result = ['some_text_field:"some_value"']
     assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result

--- a/ckanext/search/tests/solr/test_solr_provider.py
+++ b/ckanext/search/tests/solr/test_solr_provider.py
@@ -1,0 +1,153 @@
+import datetime
+
+import pytest
+from ckan.plugins.toolkit import config
+
+from ckanext.search.filters import FilterOp
+from ckanext.search.interfaces import SearchSchema
+from ckanext.search.providers.solr import SolrSearchProvider
+
+
+pytestmark = pytest.mark.skipif(
+    config.get("ckan.search.search_backend") != "solr",
+    reason="These tests are Solr specific",
+)
+
+
+SEARCH_SCHEMA: SearchSchema = {
+    "version": 1,
+    "fields": {
+        "some_text_field": {"type": "text"},
+        "some_numeric_field": {
+            "type": "number"  # TODO: still not defined (probably need int,...)
+        },
+        "some_date_field": {"type": "date"},
+    },
+}
+
+
+@pytest.fixture
+def ssp():
+
+    return SolrSearchProvider()
+
+
+@pytest.mark.parametrize(
+    "filters,result",
+    [
+        (
+            FilterOp(field="some_text_field", op="eq", value="some_value"),
+            ['some_text_field:"some_value"'],
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="eq", value=2),
+            ["some_numeric_field:2"],
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="eq", value="2"),
+            ["some_numeric_field:2"],
+        ),
+    ],
+)
+def test_filters_builtin_operations_eq(ssp, filters, result):
+
+    assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_builtin_operations_eq_date(ssp):
+    now = datetime.datetime.now().isoformat()
+    filters = FilterOp(
+        field="some_date_field",
+        op="eq",
+        value=now,
+    )
+
+    # Dates not in range filters are quoted
+    result = [f'some_date_field:"{now}"']
+
+    assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result
+
+
+@pytest.mark.parametrize(
+    "filters,result",
+    [
+        (
+            FilterOp(field="some_numeric_field", op="gt", value=5),
+            ["some_numeric_field:{5 TO *}"],
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="gte", value=5),
+            ["some_numeric_field:[5 TO *]"],
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="lt", value=5),
+            ["some_numeric_field:{* TO 5}"],
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="lte", value=5),
+            ["some_numeric_field:[* TO 5]"],
+        ),
+    ],
+)
+def test_filters_builtin_operations_ranges_numbers(ssp, filters, result):
+
+    assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result
+
+
+@pytest.mark.parametrize(
+    "filters,result",
+    [
+        (
+            FilterOp(field="some_date_field", op="gt", value="2025-06-06T00:00:00Z"),
+            ["some_date_field:{2025-06-06T00:00:00Z TO *}"],
+        ),
+        (
+            FilterOp(field="some_date_field", op="gte", value="2025-06-06T00:00:00Z"),
+            ["some_date_field:[2025-06-06T00:00:00Z TO *]"],
+        ),
+        (
+            FilterOp(field="some_date_field", op="lt", value="2025-06-06T00:00:00Z"),
+            ["some_date_field:{* TO 2025-06-06T00:00:00Z}"],
+        ),
+        (
+            FilterOp(field="some_date_field", op="lte", value="2025-06-06T00:00:00Z"),
+            ["some_date_field:[* TO 2025-06-06T00:00:00Z]"],
+        ),
+    ],
+)
+def test_filters_builtin_operations_ranges_dates(ssp, filters, result):
+
+    assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result
+
+
+def test_filters_unknown_field_is_quoted(ssp):
+    filters = FilterOp(
+        field="unknown_field",
+        op="eq",
+        value="some_value",
+    )
+    result = ['unknown_field:"some_value"']
+
+    assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result
+
+
+@pytest.mark.parametrize(
+    "filters,result",
+    [
+        (
+            FilterOp(field="some_text_field", op="eq", value='some "quoted" value'),
+            ['some_text_field:"some \\"quoted\\" value"'],
+        ),
+        (
+            FilterOp(field="some_numeric_field", op="eq", value='some "quoted" value'),
+            ['some_numeric_field:some \\"quoted\\" value'],
+        ),
+        (
+            FilterOp(field="some_date_field", op="eq", value='some "quoted" value'),
+            ['some_date_field:"some \\"quoted\\" value"'],
+        ),
+    ],
+)
+def test_filters_quotes_are_escaped(ssp, filters, result):
+
+    assert ssp._filterop_to_solr_fq(filters, SEARCH_SCHEMA) == result

--- a/test-elasticsearch.ini
+++ b/test-elasticsearch.ini
@@ -3,6 +3,8 @@ use = config:test.ini
 
 ckan.search.search_backend = elasticsearch
 
+ckan.plugins = search search_elasticsearch
+
 ckan.search.elasticsearch.url = http://localhost:9200
 #ckan.search.elasticsearch.password = test1234
 #ckan.search.elasticsearch.ca_certs_path = /path/to/http_ca.crt

--- a/test-elasticsearch.ini
+++ b/test-elasticsearch.ini
@@ -1,18 +1,12 @@
-[DEFAULT]
-debug = false
-smtp_server = localhost
-error_email_from = ckan@localhost
-
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:test.ini
 
-# Insert any custom config settings to be used when running your extension's
-# tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = search search_solr search_elasticsearch
+ckan.search.search_backend = elasticsearch
 
-ckan.search.search_backend = solr
-
-ckan.search.solr.url = http://localhost:8983/solr/ckan-test
+ckan.search.elasticsearch.url = http://localhost:9200
+#ckan.search.elasticsearch.password = test1234
+#ckan.search.elasticsearch.ca_certs_path = /path/to/http_ca.crt
+ckan.search.elasticsearch.index_name = ckan-test
 
 # Logging configuration
 [loggers]
@@ -52,3 +46,4 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s
+

--- a/test-solr.ini
+++ b/test-solr.ini
@@ -1,18 +1,11 @@
-[DEFAULT]
-debug = false
-smtp_server = localhost
-error_email_from = ckan@localhost
-
 [app:main]
-use = config:../ckan/test-core.ini
-
-# Insert any custom config settings to be used when running your extension's
-# tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = search search_solr search_elasticsearch
+use = config:test.ini
 
 ckan.search.search_backend = solr
 
 ckan.search.solr.url = http://localhost:8983/solr/ckan-test
+
+
 
 # Logging configuration
 [loggers]

--- a/test-solr.ini
+++ b/test-solr.ini
@@ -1,6 +1,8 @@
 [app:main]
 use = config:test.ini
 
+ckan.plugins = search search_solr 
+
 ckan.search.search_backend = solr
 
 ckan.search.solr.url = http://localhost:8983/solr/ckan-test

--- a/test.ini
+++ b/test.ini
@@ -6,13 +6,11 @@ error_email_from = ckan@localhost
 [app:main]
 use = config:../ckan/test-core.ini
 
-# Insert any custom config settings to be used when running your extension's
-# tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = search search_solr search_elasticsearch
+ckan.plugins = search
 
-ckan.search.search_backend = solr
+#ckan.search.search_backend = solr
 
-ckan.search.solr.url = http://localhost:8983/solr/ckan-test
+#ckan.search.solr.url = http://localhost:8983/solr/ckan-test
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
Follow up from #1, integrating FilterOps handling in Solr and ES providers

Lots of mixed changes to improve the test suite but the interesting bits are the following:

* Functions to translate FilterOps to [Solr](https://github.com/amercader/ckanext-search/pull/2/files#diff-ba44da2df03cf284eca99ade7d5d21865769bc5656618f00f25656caf3ab3f03R391) and [Elasticsearch](https://github.com/amercader/ckanext-search/pull/2/files#diff-5c09a55eeaa05092be9d739ee9e5b183ec324f44b2e89cff1b18e82820630ffeR146) filters syntax
* [Solr](https://github.com/amercader/ckanext-search/pull/2/files#diff-bc75d2d6f31ddb035d2c6ff24eb2aa18ce2d2728ab170fe04f8f58e583e8b766) and [Elasticsearch](https://github.com/amercader/ckanext-search/pull/2/files#diff-5696f4b6951acc107aa75ce14745ff30abe3213c4507b72a0120808b0a49c6c4) specific tests to test the functionality above
* Provider-agnostic test suite that tests expected outputs using the generic filters interface: [test_query_filters.py](https://github.com/amercader/ckanext-search/pull/2/files#diff-ae25852aed565f1fe2728bca94d8c752761dcd9dc293313dda3135055ac49a58). These are run both under [Solr and Elasticsearch](https://github.com/amercader/ckanext-search/actions/runs/15704810543/job/44248012625), and the idea is to expand them to cover all functionality that a provider needs to cover to be compliant