### PR TITLE
Per-entity search

### DIFF
--- a/ckanext/search/cli.py
+++ b/ckanext/search/cli.py
@@ -1,8 +1,7 @@
 import click
 
 from ckanext.search.index import (
-    rebuild_dataset_index,
-    rebuild_organization_index,
+    rebuild_index,
     clear_index,
 )
 from ckanext.search.schema import init_schema
@@ -21,15 +20,7 @@ def rebuild(entity_type: str):
     # TODO: hook ISearchEntity here!
     # TODO: wrap in actions
 
-
-    if entity_type == "dataset":
-        rebuild_dataset_index()
-    elif entity_type == "organization":
-        rebuild_organization_index()
-    elif entity_type is None:
-
-        rebuild_organization_index()
-        rebuild_dataset_index()
+    rebuild_index(entity_type)
 
 
 @search.command()

--- a/ckanext/search/cli.py
+++ b/ckanext/search/cli.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import click
 
 from ckanext.search.index import (
@@ -14,13 +15,20 @@ def search():
 
 
 @search.command()
+@click.option(
+    "-i",
+    "--id",
+    "ids",
+    multiple=True,
+    help="Id of specific entity to index (can be provided multiple times)",
+)
 @click.argument("entity_type", required=False)
-def rebuild(entity_type: str):
+def rebuild(entity_type: str, ids: Optional[list] = None):
 
     # TODO: hook ISearchEntity here!
     # TODO: wrap in actions
 
-    rebuild_index(entity_type)
+    rebuild_index(entity_type, ids)
 
 
 @search.command()

--- a/ckanext/search/cli.py
+++ b/ckanext/search/cli.py
@@ -18,6 +18,10 @@ def search():
 @click.argument("entity_type", required=False)
 def rebuild(entity_type: str):
 
+    # TODO: hook ISearchEntity here!
+    # TODO: wrap in actions
+
+
     if entity_type == "dataset":
         rebuild_dataset_index()
     elif entity_type == "organization":

--- a/ckanext/search/entities/__init__.py
+++ b/ckanext/search/entities/__init__.py
@@ -1,0 +1,2 @@
+from .dataset import DatasetSearchEntity
+from .organization import OrganizationSearchEntity

--- a/ckanext/search/entities/dataset.py
+++ b/ckanext/search/entities/dataset.py
@@ -1,0 +1,267 @@
+import json
+from typing import Any, Iterable, Optional
+
+import ckan.authz as authz
+from ckan import model
+from ckan.lib.navl.dictization_functions import MissingNullEncoder
+from ckan.lib.plugins import get_permission_labels
+from ckan.plugins import SingletonPlugin
+from ckan.plugins.toolkit import NotFound, config, get_action, get_validator
+from ckan.types import ActionResult, Context, Schema
+
+from ckanext.search.filters import FilterOp
+from ckanext.search.schema import (DEFAULT_DATASET_SEARCH_SCHEMA, SearchSchema,
+                                   get_search_schema)
+
+
+class DatasetSearchEntity(SingletonPlugin):
+
+    def entity_type(self) -> str:
+        """Return a string id for the entity that this plugin handles
+        (e.g. 'dataset', 'organization', 'report', etc)"""
+
+        return "dataset"
+
+    def search_schema(self) -> SearchSchema:
+        """Return a full search schema for this particular entity type.
+
+        TODO: link to docs with a proper spec
+        Search schemas are defined as dicts with the following format:
+
+            {
+                "version": 1,
+                "fields": {
+                    <field_name>: {
+                        "type": <type>,
+                        "multiple": True/False,
+                        "indexed": True/False,
+                        "stored": True/False,
+                        ...
+                    },
+                    ...
+
+                    }
+                }
+
+            }
+
+        """
+        return DEFAULT_DATASET_SEARCH_SCHEMA
+
+    def search_query_schema(self) -> Schema:
+        """
+        Return a schema to validate custom query parameters. Can be used to add new
+        supported query parameters.
+
+        For datasets, these are:
+
+        * include_drafts: if ``True``, draft datasets will be included in the
+            results. A user will only be returned their own draft datasets, and a
+            sysadmin will be returned all draft datasets. Optional, the default is
+            ``False``.
+        * include_deleted: if ``True``, deleted datasets will be included in the
+            results (site configuration "ckan.search.remove_deleted_packages" must
+            be set to False). Optional, the default is ``False``.
+        * include_private: if ``True``, private datasets will be included in
+            the results. Only private datasets from the user's organizations will
+            be returned and sysadmins will be returned all private datasets.
+            Optional, the default is ``False``.
+        """
+        search_query_schema = {}
+
+        ignore_missing = get_validator("ignore_missing")
+        ignore_empty = get_validator("ignore_empty")
+        boolean_validator = get_validator("boolean_validator")
+
+        search_query_schema["include_drafts"] = [
+            ignore_missing,
+            ignore_empty,
+            boolean_validator,
+        ]
+        search_query_schema["include_deleted"] = [
+            ignore_missing,
+            ignore_empty,
+            boolean_validator,
+        ]
+        search_query_schema["include_private"] = [
+            ignore_missing,
+            ignore_empty,
+            boolean_validator,
+        ]
+
+        return search_query_schema
+
+    def _get_user_permission_labels(self, context: Context) -> list[str] | None:
+
+        user = context.get("user")
+        if context.get("ignore_auth") or (user and authz.is_sysadmin(user)):
+            labels = None
+        else:
+            labels = get_permission_labels().get_user_dataset_labels(
+                context["auth_user_obj"]
+            )
+
+        return labels
+
+    def _add_filter_to_query(
+        self, query_params: dict[str, Any], filter_op: FilterOp
+    ) -> dict[str, Any]:
+
+        if existing_filter_op := query_params["filters"]:
+            if existing_filter_op.op == "$and":
+                # Add the filter to the existing AND filters
+                existing_filter_op.value.append(filter_op)
+            else:
+                # Wrap existing filters and the new one in an AND operation
+                query_params["filters"] = FilterOp(
+                    field=None, op="$and", value=[existing_filter_op, filter_op]
+                )
+            pass
+        else:
+            # If no filters already defined, just use the new filter
+            query_params["filters"] = filter_op
+
+        return query_params
+
+    def before_query(
+        self, query_params: dict[str, Any], context: Context
+    ) -> dict[str, Any]:
+        """
+        Called before sending the query to the search provider, allows to modify
+        the sent query parameters.
+        """
+
+        include_drafts = query_params.get("additional_params", {}).pop(
+            "include_drafts", False
+        )
+        include_deleted = query_params.get("additional_params", {}).pop(
+            "include_deleted", False
+        )
+        include_private = query_params.get("additional_params", {}).pop(
+            "include_private", False
+        )
+
+        if not include_private:
+            private_filter = FilterOp(field="private", op="eq", value=False)
+            self._add_filter_to_query(query_params, private_filter)
+
+        # TODO: Check if state is previously defined in filters
+        # https://github.com/ckan/ckan/blob/89107b266508a830e903d2765670827380f1e5ae/ckan/logic/action/get.py#L1841
+        states = ["active"]
+        if include_drafts:
+            states.append("draft")
+        if include_deleted:
+            states.append("deleted")
+        states_filter = FilterOp(field="state", op="in", value=states)
+        self._add_filter_to_query(query_params, states_filter)
+
+        # Permission labels
+        if labels := self._get_user_permission_labels(context):
+            perm_labels_filter_op = FilterOp(
+                field="permission_labels", op="in", value=labels
+            )
+            self._add_filter_to_query(query_params, perm_labels_filter_op)
+
+        return query_params
+
+    def after_query(
+        self, query_results: dict[str, Any], query_params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Called just before returning the search results. Besides the results from
+        the provider, it also receives the params used in the query.
+        """
+
+        return query_results
+
+    def _get_dataset_ids(self, ids: Optional[Iterable[str]] = []) -> Iterable[str]:
+
+        q = model.Session.query(model.Package.id)
+        if ids:
+            q = q.filter(model.Package.id.in_(ids))
+
+        # TODO: review this
+        if config.get("ckan.search.remove_deleted_packages"):
+            package_ids = q.filter(model.Package.state != "deleted")
+
+        package_ids = [r[0] for r in q.all()]
+
+        if ids and len(package_ids) != len(list(ids)):
+            missing_ids = {id_ for id_ in package_ids} - set(ids)
+            raise NotFound(f"Dataset with id(s) not found: {missing_ids}")
+
+        return package_ids
+
+    def _get_dataset_dict(self, id_: str) -> ActionResult.PackageShow:
+        context = {
+            "ignore_auth": True,
+            "use_cache": False,
+            # "for_indexing": True,  # TODO: implement support in core?
+        }
+
+        # Request the validated dataset
+        dataset_dict = get_action("package_show")(context, {"id": id_})
+
+        return dataset_dict
+
+    def _transform_search_data(
+        self, dataset_dict: ActionResult.PackageShow
+    ) -> dict[str, Any]:
+
+        # TODO: make this a public interface method? i.e is it useful elsewhere?
+
+        search_data = {}
+
+        # TODO: choose what to index here?
+        # For now let's remove everything not explicitly added to the search schema
+        schema = get_search_schema("dataset")
+        for key, value in dataset_dict.items():
+
+            # TODO: handle organization, resource fields, etc
+            if key in schema.get("fields", []):
+                search_data[key] = value
+
+        search_data["tags"] = [t["name"] for t in search_data.get("tags", [])]
+
+        # Add search-specific fields
+
+        search_data["entity_type"] = "dataset"
+
+        search_data["validated_data_dict"] = json.dumps(
+            search_data, cls=MissingNullEncoder
+        )
+
+        # permission labels determine visibility in search, can't be set
+        # in original dataset or before_dataset_index plugins
+        id_ = dataset_dict["id"]
+        search_data["permission_labels"] = get_permission_labels().get_dataset_labels(
+            model.Package.get(id_)
+        )
+
+        return search_data
+
+    def existing_record_ids(self, entity_type: str) -> Iterable[str]:
+        """return a list or iterable of all record ids for the given entity type
+        managed by this feature.
+        This method is used to identify missing and orphan records in the
+        search index"""
+
+        # TODO: do we really need entity_type?
+        assert entity_type == "dataset"
+
+        return self._get_dataset_ids()
+
+    def fetch_records(
+        self, entity_type: str, ids: Optional[Iterable[str]] = []
+    ) -> Iterable[dict[str, Any]]:
+        """generator of all records for this entity type managed by this
+        feature, or only records for the ids passed if not None.
+        This method is used to rebuild all or some records in the search
+        index"""
+
+        # TODO: do we really need entity_type?
+        assert entity_type == "dataset"
+
+        for id_ in self._get_dataset_ids(ids):
+            dataset_dict = self._get_dataset_dict(id_)
+            yield self._transform_search_data(dataset_dict)

--- a/ckanext/search/entities/organization.py
+++ b/ckanext/search/entities/organization.py
@@ -1,0 +1,157 @@
+import json
+from typing import Any, Iterable, Optional
+
+import ckan.authz as authz
+from ckan import model
+from ckan.lib.navl.dictization_functions import MissingNullEncoder
+from ckan.lib.plugins import get_permission_labels
+from ckan.plugins import SingletonPlugin
+from ckan.plugins.toolkit import NotFound, config, get_action, get_validator
+from ckan.types import ActionResult, Context, Schema
+from sqlalchemy.sql.expression import true
+
+from ckanext.search.filters import FilterOp
+from ckanext.search.schema import (DEFAULT_ORGANIZATION_SEARCH_SCHEMA,
+                                   SearchSchema, get_search_schema)
+
+
+class OrganizationSearchEntity(SingletonPlugin):
+
+    def entity_type(self) -> str:
+        """Return a string id for the entity that this plugin handles
+        (e.g. 'dataset', 'organization', 'report', etc)"""
+
+        return "organization"
+
+    def search_schema(self) -> SearchSchema:
+        """Return a full search schema for this particular entity type.
+
+        TODO: link to docs with a proper spec
+        Search schemas are defined as dicts with the following format:
+
+            {
+                "version": 1,
+                "fields": {
+                    <field_name>: {
+                        "type": <type>,
+                        "multiple": True/False,
+                        "indexed": True/False,
+                        "stored": True/False,
+                        ...
+                    },
+                    ...
+
+                    }
+                }
+
+            }
+
+        """
+        return DEFAULT_ORGANIZATION_SEARCH_SCHEMA
+
+    def search_query_schema(self) -> Schema:
+        """
+        Return a schema to validate custom query parameters. Can be used to add new
+        supported query parameters.
+        """
+
+        return {}
+
+    def before_query(
+        self, query_params: dict[str, Any], context: Context
+    ) -> dict[str, Any]:
+        """
+        Called before sending the query to the search provider, allows to modify
+        the sent query parameters.
+        """
+
+        return query_params
+
+    def after_query(
+        self, query_results: dict[str, Any], query_params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Called just before returning the search results. Besides the results from
+        the provider, it also receives the params used in the query.
+        """
+
+        return query_results
+
+    def _get_org_ids(self, ids: Optional[Iterable[str]] = []) -> Iterable[str]:
+
+        # TODO: more filters (state, type, etc)?
+        q = (
+            model.Session.query(model.Group.id)
+            .filter(model.Group.state != "deleted")
+            .filter(model.Group.is_organization == true())
+        )
+        if ids:
+            q = q.filter(model.Group.id.in_(ids))
+
+        org_ids = [r[0] for r in q.all()]
+
+        if ids and len(org_ids) != len(list(ids)):
+            missing_ids = {id_ for id_ in org_ids} - set(ids)
+            raise NotFound(f"Organization with id(s) not found: {missing_ids}")
+
+        return org_ids
+
+    def _get_org_dict(self, id_: str) -> ActionResult.OrganizationShow:
+        context = {
+            "ignore_auth": True,
+            "use_cache": False,
+            # "for_indexing": True,  # TODO: implement support in core?
+        }
+
+        # Request the validated dataset
+        org_dict = get_action("organization_show")(context, {"id": id_})
+
+        return org_dict
+
+    def _transform_search_data(
+        self, org_dict: ActionResult.PackageShow
+    ) -> dict[str, Any]:
+
+        # TODO: make this a public interface method? i.e is it useful elsewhere?
+
+        search_data = {}
+
+        # For now let's remove everything not explicitly added to the search schema
+        schema = get_search_schema("organization")
+        for key, value in org_dict.items():
+            # TODO: handle users etc?
+            if key in schema.get("fields", []):
+                search_data[key] = value
+
+        search_data["entity_type"] = "organization"
+        search_data["validated_data_dict"] = json.dumps(
+            search_data, cls=MissingNullEncoder
+        )
+
+        return search_data
+
+    def existing_record_ids(self, entity_type: str) -> Iterable[str]:
+        """return a list or iterable of all record ids for the given entity type
+        managed by this feature.
+        This method is used to identify missing and orphan records in the
+        search index"""
+
+        # TODO: do we really need entity_type?
+        assert entity_type == "organization"
+
+        return self._get_org_ids()
+
+    def fetch_records(
+        self, entity_type: str, ids: Optional[Iterable[str]] = []
+    ) -> Iterable[dict[str, Any]]:
+        """generator of all records for this entity type managed by this
+        feature, or only records for the ids passed if not None.
+        This method is used to rebuild all or some records in the search
+        index"""
+
+        # TODO: do we really need entity_type?
+        assert entity_type == "organization"
+
+        for id_ in self._get_org_ids(ids):
+            org_dict = self._get_org_dict(id_)
+            yield self._transform_search_data(org_dict)

--- a/ckanext/search/index.py
+++ b/ckanext/search/index.py
@@ -106,7 +106,7 @@ def index_organization_dict(org_dict: ActionResult.OrganizationShow) -> None:
 
 def _index_record(entity_type: str, id_: str, search_data: dict) -> None:
 
-    search_schema = get_search_schema()
+    search_schema = get_search_schema(entity_type)
 
     for provider_plugin in PluginImplementations(ISearchProvider):
         if provider_plugin.id in _get_indexing_providers():

--- a/ckanext/search/index.py
+++ b/ckanext/search/index.py
@@ -1,17 +1,30 @@
 import json
+import logging
+import time
+from typing import Any, Iterable, Optional
 from collections.abc import Iterator
 
 from sqlalchemy.sql.expression import true
 
 from ckan import model
+
+import ckan.authz as authz
 from ckan.lib.navl.dictization_functions import MissingNullEncoder
 from ckan.lib.plugins import get_permission_labels
 from ckan.plugins import PluginImplementations, SingletonPlugin
-from ckan.plugins.toolkit import aslist, config, get_action
-from ckan.types import ActionResult
+from ckan.plugins.toolkit import aslist, config, get_action, get_validator, NotFound
+from ckan.types import ActionResult, Schema, Context
 
-from ckanext.search.interfaces import ISearchProvider, ISearchFeature
-from ckanext.search.schema import get_search_schema
+from ckanext.search.filters import FilterOp
+from ckanext.search.interfaces import ISearchProvider, ISearchFeature, ISearchEntity
+from ckanext.search.schema import (
+    get_search_schema,
+    SearchSchema,
+    DEFAULT_DATASET_SEARCH_SCHEMA,
+    DEFAULT_ORGANIZATION_SEARCH_SCHEMA,
+)
+
+log = logging.getLogger(__name__)
 
 
 def _get_indexing_providers() -> list:
@@ -68,10 +81,11 @@ def index_dataset_dict(dataset_dict: ActionResult.PackageShow) -> None:
     # permission labels determine visibility in search, can't be set
     # in original dataset or before_dataset_index plugins
     id_ = dataset_dict["id"]
-    labels = get_permission_labels()
-    search_data["permission_labels"] = labels.get_dataset_labels(model.Package.get(id_))
+    search_data["permission_labels"] = get_permission_labels().get_dataset_labels(
+        model.Package.get(dataset_dict["id"])
+    )
 
-    _index_record("dataset", search_data["id"], search_data)
+    return search_data
 
 
 def index_organization(id_: str) -> None:
@@ -126,6 +140,7 @@ def _index_record(entity_type: str, id_: str, search_data: dict) -> None:
             provider_plugin.index_search_record(
                 entity_type, id_, search_data, search_schema
             )
+            log.debug(f"Indexed document of type '{entity_type}' with id '{id_}'")
 
 
 def rebuild_dataset_index() -> None:
@@ -138,9 +153,12 @@ def rebuild_dataset_index() -> None:
         )  # TODO: more filters (state, type, etc)?
         .all()
     ]
-
+    t1 = time.time()
     for id_ in dataset_ids:
         index_dataset(id_)
+
+    t2 = time.time()
+    log.debug(f"Done in {t2 -t1:.2f} seconds")
 
 
 def rebuild_organization_index() -> None:
@@ -163,3 +181,255 @@ def clear_index():
     for plugin in PluginImplementations(ISearchProvider):
         if plugin.id in _get_indexing_providers():
             plugin.clear_index()
+
+
+class DatasetSearchIndex(SingletonPlugin):
+
+    def entity_type(self) -> str:
+        """Return a string id for the entity that this plugin handles
+        (e.g. 'dataset', 'organization', 'report', etc)"""
+
+        return "dataset"
+
+    def search_schema(self) -> SearchSchema:
+        """Return a full search schema for this particular entity type.
+
+        TODO: link to docs with a proper spec
+        Search schemas are defined as dicts with the following format:
+
+            {
+                "version": 1,
+                "fields": {
+                    <field_name>: {
+                        "type": <type>,
+                        "multiple": True/False,
+                        "indexed": True/False,
+                        "stored": True/False,
+                        ...
+                    },
+                    ...
+
+                    }
+                }
+
+            }
+
+        """
+        return DEFAULT_DATASET_SEARCH_SCHEMA
+
+    def search_query_schema(self) -> Schema:
+        """
+        Return a schema to validate custom query parameters. Can be used to add new
+        supported query parameters.
+
+        For datasets, these are:
+
+        * include_drafts: if ``True``, draft datasets will be included in the
+            results. A user will only be returned their own draft datasets, and a
+            sysadmin will be returned all draft datasets. Optional, the default is
+            ``False``.
+        * include_deleted: if ``True``, deleted datasets will be included in the
+            results (site configuration "ckan.search.remove_deleted_packages" must
+            be set to False). Optional, the default is ``False``.
+        * include_private: if ``True``, private datasets will be included in
+            the results. Only private datasets from the user's organizations will
+            be returned and sysadmins will be returned all private datasets.
+            Optional, the default is ``False``.
+        """
+        search_query_schema = {}
+
+        ignore_missing = get_validator("ignore_missing")
+        ignore_empty = get_validator("ignore_empty")
+        boolean_validator = get_validator("boolean_validator")
+
+        search_query_schema["include_drafts"] = [
+            ignore_missing,
+            ignore_empty,
+            boolean_validator,
+        ]
+        search_query_schema["include_deleted"] = [
+            ignore_missing,
+            ignore_empty,
+            boolean_validator,
+        ]
+        search_query_schema["include_private"] = [
+            ignore_missing,
+            ignore_empty,
+            boolean_validator,
+        ]
+
+        return search_query_schema
+
+    def _get_user_permission_labels(self, context: Context) -> list[str] | None:
+
+        user = context.get("user")
+        if context.get("ignore_auth") or (user and authz.is_sysadmin(user)):
+            labels = None
+        else:
+            labels = get_permission_labels().get_user_dataset_labels(
+                context["auth_user_obj"]
+            )
+
+        return labels
+
+    def _add_filter_to_query(
+        self, query_params: dict[str, Any], filter_op: FilterOp
+    ) -> dict[str, Any]:
+
+        if existing_filter_op := query_params["filters"]:
+            if existing_filter_op.op == "$and":
+                # Add the filter to the existing AND filters
+                existing_filter_op.value.append(filter_op)
+            else:
+                # Wrap existing filters and the new one in an AND operation
+                query_params["filters"] = FilterOp(
+                    field=None, op="$and", value=[existing_filter_op, filter_op]
+                )
+            pass
+        else:
+            # If no filters already defined, just use the new filter
+            query_params["filters"] = filter_op
+
+        return query_params
+
+    def before_query(
+        self, query_params: dict[str, Any], context: Context
+    ) -> dict[str, Any]:
+        """
+        Called before sending the query to the search provider, allows to modify
+        the sent query parameters.
+        """
+
+        include_drafts = query_params.get("additional_params", {}).pop(
+            "include_drafts", False
+        )
+        include_deleted = query_params.get("additional_params", {}).pop(
+            "include_deleted", False
+        )
+        include_private = query_params.get("additional_params", {}).pop(
+            "include_private", False
+        )
+
+        if not include_private:
+            private_filter = FilterOp(field="private", op="eq", value=False)
+            self._add_filter_to_query(query_params, private_filter)
+
+        # TODO: Check if state is previously defined in filters
+        # https://github.com/ckan/ckan/blob/89107b266508a830e903d2765670827380f1e5ae/ckan/logic/action/get.py#L1841
+        states = ["active"]
+        if include_drafts:
+            states.append("draft")
+        if include_deleted:
+            states.append("deleted")
+        states_filter = FilterOp(field="state", op="in", value=states)
+        self._add_filter_to_query(query_params, states_filter)
+
+        # Permission labels
+        if labels := self._get_user_permission_labels(context):
+            perm_labels_filter_op = FilterOp(
+                field="permission_labels", op="in", value=labels
+            )
+            self._add_filter_to_query(query_params, perm_labels_filter_op)
+
+        return query_params
+
+    def after_query(
+        self, query_results: dict[str, Any], query_params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Called just before returning the search results. Besides the results from
+        the provider, it also receives the params used in the query.
+        """
+
+        return query_results
+
+    def _get_dataset_ids(self, ids: Optional[Iterable[str]] = []) -> Iterable[str]:
+
+        q = model.Session.query(model.Package.id)
+        if ids:
+            q.filter(model.Package.id._in(ids))
+
+        # TODO: review this
+        if config.get("ckan.search.remove_deleted_packages"):
+            package_ids = q.filter(model.Package.state != "deleted")
+
+        package_ids = q.all()
+        if ids and len(package_ids) != len(list(ids)):
+            missing_ids = {id_ for id_ in package_ids} - set(ids)
+            raise NotFound(f"Dataset with id(s) not found: {missing_ids}")
+
+        return package_ids
+
+    def _get_dataset_dict(self, id_: str) -> ActionResult.PackageShow:
+        context = {
+            "ignore_auth": True,
+            "use_cache": False,
+            # "for_indexing": True,  # TODO: implement support in core?
+        }
+
+        # Request the validated dataset
+        dataset_dict = get_action("package_show")(context, {"id": id_})
+
+        return index_dataset_dict(dataset_dict)
+
+    def _transform_search_data(
+        self, dataset_dict: ActionResult.PackageShow
+    ) -> dict[str, Any]:
+
+        # TODO: make this a public interface method? i.e is it useful elsewhere?
+
+        search_data = {}
+
+        # TODO: choose what to index here?
+        # For now let's remove everything not explicitly added to the search schema
+        schema = get_search_schema("dataset")
+        for key, value in dataset_dict.items():
+
+            # TODO: handle organization, resource fields, etc
+            if key in schema.get("fields", []):
+                search_data[key] = value
+
+        search_data["tags"] = [t["name"] for t in search_data.get("tags", [])]
+
+        # Add search-specific fields
+
+        search_data["entity_type"] = "dataset"
+
+        search_data["validated_data_dict"] = json.dumps(
+            search_data, cls=MissingNullEncoder
+        )
+
+        # permission labels determine visibility in search, can't be set
+        # in original dataset or before_dataset_index plugins
+        id_ = dataset_dict["id"]
+        search_data["permission_labels"] = get_permission_labels().get_dataset_labels(
+            model.Package.get(id_)
+        )
+
+        return search_data
+
+    def existing_record_ids(self, entity_type: str) -> Iterable[str]:
+        """return a list or iterable of all record ids for the given entity type
+        managed by this feature.
+        This method is used to identify missing and orphan records in the
+        search index"""
+
+        # TODO: do we really need entity_type?
+        assert entity_type == "dataset"
+
+        return self._get_dataset_ids()
+
+    def fetch_records(
+        self, entity_type: str, ids: Optional[Iterable[str]] = []
+    ) -> Iterable[dict[str, Any]]:
+        """generator of all records for this entity type managed by this
+        feature, or only records for the ids passed if not None.
+        This method is used to rebuild all or some records in the search
+        index"""
+
+        # TODO: do we really need entity_type?
+        assert entity_type == "dataset"
+
+        for id_ in self._get_dataset_ids(ids):
+            dataset_dict = self._get_dataset_dict(id_)
+            yield self._transform_search_data(dataset_dict)

--- a/ckanext/search/index.py
+++ b/ckanext/search/index.py
@@ -1,27 +1,16 @@
-import json
 import logging
-import time
-from typing import Any, Iterable, Optional
+from typing import Optional
 from collections.abc import Iterator
-
-from sqlalchemy.sql.expression import true
 
 from ckan import model
 
-import ckan.authz as authz
-from ckan.lib.navl.dictization_functions import MissingNullEncoder
-from ckan.lib.plugins import get_permission_labels
 from ckan.plugins import PluginImplementations, SingletonPlugin
-from ckan.plugins.toolkit import aslist, config, get_action, get_validator, NotFound
-from ckan.types import ActionResult, Schema, Context
+from ckan.plugins.toolkit import aslist, config
 
-from ckanext.search.filters import FilterOp
+from ckanext.search.entities import DatasetSearchEntity, OrganizationSearchEntity
 from ckanext.search.interfaces import ISearchProvider, ISearchFeature, ISearchEntity
 from ckanext.search.schema import (
     get_search_schema,
-    SearchSchema,
-    DEFAULT_DATASET_SEARCH_SCHEMA,
-    DEFAULT_ORGANIZATION_SEARCH_SCHEMA,
 )
 
 log = logging.getLogger(__name__)
@@ -48,7 +37,7 @@ def _get_entity_plugins(entity_type: Optional[str] = None):
     # TODO: make core entities extendable but not registered,
     # similar to DefaultDatasetForm
 
-    entity_plugins = [DatasetSearchIndex()] + [
+    entity_plugins = [DatasetSearchEntity(), OrganizationSearchEntity()] + [
         p for p in PluginImplementations(ISearchEntity)
     ]
     if entity_type:
@@ -59,36 +48,6 @@ def _get_entity_plugins(entity_type: Optional[str] = None):
         return entity_plugin
 
     return entity_plugins
-
-
-def index_organization(id_: str) -> None:
-
-    context = {
-        "ignore_auth": True,
-        "use_cache": False,  # TODO: not really used in core outside datasets
-        # "for_indexing": True,  # TODO: implement support in core
-    }
-    org_dict = get_action("organization_show")(context, {"id": id_})
-
-    return index_organization_dict(org_dict)
-
-
-def index_organization_dict(org_dict: ActionResult.OrganizationShow) -> None:
-
-    # TODO: choose what to index here?
-    search_data = {}
-
-    # For now let's remove everything not explicitly added to the search schema
-    schema = get_search_schema("organization")
-    for key, value in org_dict.items():
-        # TODO: handle users etc?
-        if key in schema.get("fields", []):
-            search_data[key] = value
-
-    search_data["entity_type"] = "organization"
-    search_data["validated_data_dict"] = json.dumps(search_data, cls=MissingNullEncoder)
-
-    _index_record("organization", search_data["id"], search_data)
 
 
 def _index_record(entity_type: str, id_: str, search_data: dict) -> None:
@@ -116,285 +75,20 @@ def _index_record(entity_type: str, id_: str, search_data: dict) -> None:
             log.debug(f"Indexed document of type '{entity_type}' with id '{id_}'")
 
 
-def rebuild_index(entity_type: Optional[str] = None) -> None:
+def rebuild_index(
+    entity_type: Optional[str] = None, ids: Optional[list] = None
+) -> None:
 
     entity_plugins = _get_entity_plugins(entity_type)
 
     for plugin in entity_plugins:
-        log.debug(f"Indexing entities of type: {entity_type}")
-        for record in plugin.fetch_records(entity_type):
+        current_entity_type = plugin.entity_type()
+        log.debug(f"Indexing entities of type: {current_entity_type}")
+        for record in plugin.fetch_records(current_entity_type, ids):
             _index_record(plugin.entity_type(), record["id"], record)
-
-
-def rebuild_organization_index() -> None:
-
-    org_ids = [
-        r[0]
-        for r in model.Session.query(model.Group.id)
-        .filter(
-            model.Group.state != "deleted"
-        )  # TODO: more filters (state, type, etc)?
-        .filter(model.Group.is_organization == true())
-        .all()
-    ]
-
-    for id_ in org_ids:
-        index_organization(id_)
 
 
 def clear_index():
     for plugin in PluginImplementations(ISearchProvider):
         if plugin.id in _get_indexing_providers():
             plugin.clear_index()
-
-
-class DatasetSearchIndex(SingletonPlugin):
-
-    def entity_type(self) -> str:
-        """Return a string id for the entity that this plugin handles
-        (e.g. 'dataset', 'organization', 'report', etc)"""
-
-        return "dataset"
-
-    def search_schema(self) -> SearchSchema:
-        """Return a full search schema for this particular entity type.
-
-        TODO: link to docs with a proper spec
-        Search schemas are defined as dicts with the following format:
-
-            {
-                "version": 1,
-                "fields": {
-                    <field_name>: {
-                        "type": <type>,
-                        "multiple": True/False,
-                        "indexed": True/False,
-                        "stored": True/False,
-                        ...
-                    },
-                    ...
-
-                    }
-                }
-
-            }
-
-        """
-        return DEFAULT_DATASET_SEARCH_SCHEMA
-
-    def search_query_schema(self) -> Schema:
-        """
-        Return a schema to validate custom query parameters. Can be used to add new
-        supported query parameters.
-
-        For datasets, these are:
-
-        * include_drafts: if ``True``, draft datasets will be included in the
-            results. A user will only be returned their own draft datasets, and a
-            sysadmin will be returned all draft datasets. Optional, the default is
-            ``False``.
-        * include_deleted: if ``True``, deleted datasets will be included in the
-            results (site configuration "ckan.search.remove_deleted_packages" must
-            be set to False). Optional, the default is ``False``.
-        * include_private: if ``True``, private datasets will be included in
-            the results. Only private datasets from the user's organizations will
-            be returned and sysadmins will be returned all private datasets.
-            Optional, the default is ``False``.
-        """
-        search_query_schema = {}
-
-        ignore_missing = get_validator("ignore_missing")
-        ignore_empty = get_validator("ignore_empty")
-        boolean_validator = get_validator("boolean_validator")
-
-        search_query_schema["include_drafts"] = [
-            ignore_missing,
-            ignore_empty,
-            boolean_validator,
-        ]
-        search_query_schema["include_deleted"] = [
-            ignore_missing,
-            ignore_empty,
-            boolean_validator,
-        ]
-        search_query_schema["include_private"] = [
-            ignore_missing,
-            ignore_empty,
-            boolean_validator,
-        ]
-
-        return search_query_schema
-
-    def _get_user_permission_labels(self, context: Context) -> list[str] | None:
-
-        user = context.get("user")
-        if context.get("ignore_auth") or (user and authz.is_sysadmin(user)):
-            labels = None
-        else:
-            labels = get_permission_labels().get_user_dataset_labels(
-                context["auth_user_obj"]
-            )
-
-        return labels
-
-    def _add_filter_to_query(
-        self, query_params: dict[str, Any], filter_op: FilterOp
-    ) -> dict[str, Any]:
-
-        if existing_filter_op := query_params["filters"]:
-            if existing_filter_op.op == "$and":
-                # Add the filter to the existing AND filters
-                existing_filter_op.value.append(filter_op)
-            else:
-                # Wrap existing filters and the new one in an AND operation
-                query_params["filters"] = FilterOp(
-                    field=None, op="$and", value=[existing_filter_op, filter_op]
-                )
-            pass
-        else:
-            # If no filters already defined, just use the new filter
-            query_params["filters"] = filter_op
-
-        return query_params
-
-    def before_query(
-        self, query_params: dict[str, Any], context: Context
-    ) -> dict[str, Any]:
-        """
-        Called before sending the query to the search provider, allows to modify
-        the sent query parameters.
-        """
-
-        include_drafts = query_params.get("additional_params", {}).pop(
-            "include_drafts", False
-        )
-        include_deleted = query_params.get("additional_params", {}).pop(
-            "include_deleted", False
-        )
-        include_private = query_params.get("additional_params", {}).pop(
-            "include_private", False
-        )
-
-        if not include_private:
-            private_filter = FilterOp(field="private", op="eq", value=False)
-            self._add_filter_to_query(query_params, private_filter)
-
-        # TODO: Check if state is previously defined in filters
-        # https://github.com/ckan/ckan/blob/89107b266508a830e903d2765670827380f1e5ae/ckan/logic/action/get.py#L1841
-        states = ["active"]
-        if include_drafts:
-            states.append("draft")
-        if include_deleted:
-            states.append("deleted")
-        states_filter = FilterOp(field="state", op="in", value=states)
-        self._add_filter_to_query(query_params, states_filter)
-
-        # Permission labels
-        if labels := self._get_user_permission_labels(context):
-            perm_labels_filter_op = FilterOp(
-                field="permission_labels", op="in", value=labels
-            )
-            self._add_filter_to_query(query_params, perm_labels_filter_op)
-
-        return query_params
-
-    def after_query(
-        self, query_results: dict[str, Any], query_params: dict[str, Any]
-    ) -> dict[str, Any]:
-        """
-        Called just before returning the search results. Besides the results from
-        the provider, it also receives the params used in the query.
-        """
-
-        return query_results
-
-    def _get_dataset_ids(self, ids: Optional[Iterable[str]] = []) -> Iterable[str]:
-
-        q = model.Session.query(model.Package.id)
-        if ids:
-            q.filter(model.Package.id._in(ids))
-
-        # TODO: review this
-        if config.get("ckan.search.remove_deleted_packages"):
-            package_ids = q.filter(model.Package.state != "deleted")
-
-        package_ids = q.all()
-        if ids and len(package_ids) != len(list(ids)):
-            missing_ids = {id_ for id_ in package_ids} - set(ids)
-            raise NotFound(f"Dataset with id(s) not found: {missing_ids}")
-
-        return package_ids
-
-    def _get_dataset_dict(self, id_: str) -> ActionResult.PackageShow:
-        context = {
-            "ignore_auth": True,
-            "use_cache": False,
-            # "for_indexing": True,  # TODO: implement support in core?
-        }
-
-        # Request the validated dataset
-        dataset_dict = get_action("package_show")(context, {"id": id_})
-
-        return dataset_dict
-
-    def _transform_search_data(
-        self, dataset_dict: ActionResult.PackageShow
-    ) -> dict[str, Any]:
-
-        # TODO: make this a public interface method? i.e is it useful elsewhere?
-
-        search_data = {}
-
-        # TODO: choose what to index here?
-        # For now let's remove everything not explicitly added to the search schema
-        schema = get_search_schema("dataset")
-        for key, value in dataset_dict.items():
-
-            # TODO: handle organization, resource fields, etc
-            if key in schema.get("fields", []):
-                search_data[key] = value
-
-        search_data["tags"] = [t["name"] for t in search_data.get("tags", [])]
-
-        # Add search-specific fields
-
-        search_data["entity_type"] = "dataset"
-
-        search_data["validated_data_dict"] = json.dumps(
-            search_data, cls=MissingNullEncoder
-        )
-
-        # permission labels determine visibility in search, can't be set
-        # in original dataset or before_dataset_index plugins
-        id_ = dataset_dict["id"]
-        search_data["permission_labels"] = get_permission_labels().get_dataset_labels(
-            model.Package.get(id_)
-        )
-
-        return search_data
-
-    def existing_record_ids(self, entity_type: str) -> Iterable[str]:
-        """return a list or iterable of all record ids for the given entity type
-        managed by this feature.
-        This method is used to identify missing and orphan records in the
-        search index"""
-
-        # TODO: do we really need entity_type?
-        assert entity_type == "dataset"
-
-        return self._get_dataset_ids()
-
-    def fetch_records(
-        self, entity_type: str, ids: Optional[Iterable[str]] = []
-    ) -> Iterable[dict[str, Any]]:
-        """generator of all records for this entity type managed by this
-        feature, or only records for the ids passed if not None.
-        This method is used to rebuild all or some records in the search
-        index"""
-
-        # TODO: do we really need entity_type?
-        assert entity_type == "dataset"
-
-        for id_ in self._get_dataset_ids(ids):
-            dataset_dict = self._get_dataset_dict(id_)
-            yield self._transform_search_data(dataset_dict)

--- a/ckanext/search/index.py
+++ b/ckanext/search/index.py
@@ -43,49 +43,22 @@ def _get_indexing_plugins() -> Iterator[SingletonPlugin]:
             yield plugin
 
 
-def index_dataset(id_: str) -> None:
+def _get_entity_plugins(entity_type: Optional[str] = None):
 
-    context = {
-        "ignore_auth": True,
-        "use_cache": False,
-        # "for_indexing": True,  # TODO: implement support in core?
-    }
+    # TODO: make core entities extendable but not registered,
+    # similar to DefaultDatasetForm
 
-    # Request the validated dataset
-    dataset_dict = get_action("package_show")(context, {"id": id_})
+    entity_plugins = [DatasetSearchIndex()] + [
+        p for p in PluginImplementations(ISearchEntity)
+    ]
+    if entity_type:
+        entity_plugin = [p for p in entity_plugins if p.entity_type() == entity_type]
+        if not entity_plugin:
+            raise ValueError(f"Unknown search entity type: {entity_type}")
 
-    return index_dataset_dict(dataset_dict)
+        return entity_plugin
 
-
-def index_dataset_dict(dataset_dict: ActionResult.PackageShow) -> None:
-
-    # TODO: choose what to index here?
-    search_data = {}
-
-    # For now let's remove everything not explicitly added to the search schema
-    schema = get_search_schema("dataset")
-    for key, value in dataset_dict.items():
-
-        # TODO: handle organization, resource fields, etc
-        if key in schema.get("fields", []):
-            search_data[key] = value
-
-    search_data["tags"] = [t["name"] for t in search_data.get("tags", [])]
-
-    # Add search-specific fields
-
-    search_data["entity_type"] = "dataset"
-
-    search_data["validated_data_dict"] = json.dumps(search_data, cls=MissingNullEncoder)
-
-    # permission labels determine visibility in search, can't be set
-    # in original dataset or before_dataset_index plugins
-    id_ = dataset_dict["id"]
-    search_data["permission_labels"] = get_permission_labels().get_dataset_labels(
-        model.Package.get(dataset_dict["id"])
-    )
-
-    return search_data
+    return entity_plugins
 
 
 def index_organization(id_: str) -> None:
@@ -143,22 +116,14 @@ def _index_record(entity_type: str, id_: str, search_data: dict) -> None:
             log.debug(f"Indexed document of type '{entity_type}' with id '{id_}'")
 
 
-def rebuild_dataset_index() -> None:
+def rebuild_index(entity_type: Optional[str] = None) -> None:
 
-    dataset_ids = [
-        r[0]
-        for r in model.Session.query(model.Package.id)
-        .filter(
-            model.Package.state != "deleted"
-        )  # TODO: more filters (state, type, etc)?
-        .all()
-    ]
-    t1 = time.time()
-    for id_ in dataset_ids:
-        index_dataset(id_)
+    entity_plugins = _get_entity_plugins(entity_type)
 
-    t2 = time.time()
-    log.debug(f"Done in {t2 -t1:.2f} seconds")
+    for plugin in entity_plugins:
+        log.debug(f"Indexing entities of type: {entity_type}")
+        for record in plugin.fetch_records(entity_type):
+            _index_record(plugin.entity_type(), record["id"], record)
 
 
 def rebuild_organization_index() -> None:
@@ -370,7 +335,7 @@ class DatasetSearchIndex(SingletonPlugin):
         # Request the validated dataset
         dataset_dict = get_action("package_show")(context, {"id": id_})
 
-        return index_dataset_dict(dataset_dict)
+        return dataset_dict
 
     def _transform_search_data(
         self, dataset_dict: ActionResult.PackageShow

--- a/ckanext/search/interfaces.py
+++ b/ckanext/search/interfaces.py
@@ -1,7 +1,7 @@
 # This will eventually live in CKAN core
 from typing import Any, Iterable, Optional, TypedDict
 
-from ckan.types import Schema
+from ckan.types import Schema, Context
 from ckan.plugins.interfaces import Interface
 
 from ckanext.search.filters import FilterOp
@@ -118,27 +118,6 @@ class ISearchFeature(Interface):
 
         pass
 
-    def format_search_data(
-        self, entity_type: str, data: dict[str:Any]
-    ) -> dict[str, str | list[str]]:
-        """convert data for this entity type to search data suitable to be
-        passed to the search provider index method"""
-
-    def existing_record_ids(self, entity_type: str) -> Iterable[str]:
-        """return a list or iterable of all record ids for the given entity type
-        managed by this feature. Return an empty list for core entity
-        types like 'package' or entity types managed by another feature.
-        This method is used to identify missing and orphan records in the
-        search index"""
-
-    def fetch_records(
-        self, entity_type: str, records: Optional[Iterable[str]]
-    ) -> Iterable[dict[str, Any]]:
-        """generator of all records for this entity type managed by this
-        feature, or only records for the ids passed if not None.
-        This method is used to rebuild all or some records in the search
-        index"""
-
     # Querying
 
     def search_query_schema(self) -> Schema:
@@ -148,7 +127,7 @@ class ISearchFeature(Interface):
         """
         return {}
 
-    def before_query(self, query_params: dict[str, Any]) -> dict[str, Any]:
+    def before_query(self, query_params: dict[str, Any], context: Context) -> dict[str, Any]:
         """
         Called before sending the query to the search provider, allows to modify
         the sent query parameters.
@@ -165,3 +144,82 @@ class ISearchFeature(Interface):
         """
 
         return query_results
+
+
+class ISearchEntity(Interface):
+
+    def entity_type(self) -> str:
+        """Return a string id for the entity that this plugin handles
+        (e.g. 'dataset', 'organization', 'report', etc)"""
+        # TODO: Allow more than one?
+
+        # TODO: check that there's only one plugin per type at startup
+        return ""
+
+    def search_schema(self) -> SearchSchema:
+        """Return a full search schema for this particular entity type.
+
+        TODO: link to docs with a proper spec
+        Search schemas are defined as dicts with the following format:
+
+            {
+                "version": 1,
+                "fields": {
+                    <field_name>: {
+                        "type": <type>,
+                        "multiple": True/False,
+                        "indexed": True/False,
+                        "stored": True/False,
+                        ...
+                    },
+                    ...
+
+                    }
+                }
+
+            }
+
+        """
+        return {}
+
+    def search_query_schema(self) -> Schema:
+        """
+        Return a schema to validate custom query parameters. Can be used to add new
+        supported query parameters.
+        """
+        return {}
+
+    def before_query(self, query_params: dict[str, Any], context: Context) -> dict[str, Any]:
+        """
+        Called before sending the query to the search provider, allows to modify
+        the sent query parameters.
+        """
+
+        return query_params
+
+    def after_query(
+        self, query_results: dict[str, Any], query_params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Called just before returning the search results. Besides the results from
+        the provider, it also receives the params used in the query.
+        """
+
+        return query_results
+
+    def existing_record_ids(self, entity_type: str) -> Iterable[str]:
+        """return a list or iterable of all record ids for the given entity type
+        managed by this feature.
+        This method is used to identify missing and orphan records in the
+        search index"""
+
+        return []
+
+    def fetch_records(
+        self, entity_type: str, ids: Optional[Iterable[str]]
+    ) -> Iterable[dict[str, Any]]:
+        """generator of all records for this entity type managed by this
+        feature, or only records for the ids passed if not None.
+        This method is used to rebuild all or some records in the search
+        index"""
+        return iter([])

--- a/ckanext/search/interfaces.py
+++ b/ckanext/search/interfaces.py
@@ -54,7 +54,7 @@ class ISearchProvider(Interface):
 
     # TODO: what is clear used for?
     def initialize_search_provider(
-        self, combined_schema: SearchSchema, clear: bool
+        self, search_schemas: dict[str, SearchSchema], clear: bool
     ) -> None:
         """create or update indexes for fields based on combined search
         schema containing all field names, types and repeating state"""

--- a/ckanext/search/interfaces.py
+++ b/ckanext/search/interfaces.py
@@ -29,6 +29,7 @@ class ISearchProvider(Interface):
 
     def search_query(
         self,
+        entity_type: str,
         q: str,  # e.g. 'water data'
         # e.g. FilterOp(field=None, op="$and", value=[
         #   FilterOp(field="metadata_modified", op="lt", value="2024-01-01"),

--- a/ckanext/search/logic/actions.py
+++ b/ckanext/search/logic/actions.py
@@ -1,6 +1,5 @@
 # This will eventually live in ckan/logic/action/get.py
 
-import ckan.authz as authz
 from ckan.lib.plugins import get_permission_labels
 from ckan.plugins import PluginImplementations
 from ckan.plugins.toolkit import (
@@ -15,19 +14,6 @@ from ckanext.search.interfaces import ISearchProvider, ISearchFeature
 from ckanext.search.schema import get_search_schema
 from ckanext.search.logic.schema import default_search_query_schema
 from ckanext.search.filters import FilterOp
-
-
-def _get_permission_labels(context: Context) -> list[str] | None:
-
-    user = context.get("user")
-    if context.get("ignore_auth") or (user and authz.is_sysadmin(user)):
-        labels = None
-    else:
-        labels = get_permission_labels().get_user_dataset_labels(
-            context["auth_user_obj"]
-        )
-
-    return labels
 
 
 @side_effect_free
@@ -80,31 +66,10 @@ def search(context: Context, data_dict: DataDict):
 
     # Allow search extensions to modify the query params
     for plugin in PluginImplementations(ISearchFeature):
-        plugin.before_query(query_dict)
+        plugin.before_query(query_dict, context)
 
     # This is valid and a search schema exists for it
     entity_type = query_dict["entity_type"]
-
-    # Permission labels
-    # TODO: where to put this?
-    if entity_type == "dataset":
-        if labels := _get_permission_labels(context):
-            perm_labels_filter_op = FilterOp(
-                field="permission_labels", op="in", value=labels
-            )
-
-            if filter_op := query_dict["filters"]:
-                if filter_op.op == "$and":
-                    # Add the filter to the existing AND filters
-                    filter_op.value.append(perm_labels_filter_op)
-                else:
-                    # Wrap existing filters and the perms one in an AND operation
-                    query_dict["filters"] = FilterOp(
-                        field=None, op="$and", value=[filter_op, perm_labels_filter_op]
-                    )
-                pass
-            else:
-                query_dict["filters"] = perm_labels_filter_op
 
     search_schema = get_search_schema(entity_type)
     query_dict["search_schema"] = search_schema

--- a/ckanext/search/logic/actions.py
+++ b/ckanext/search/logic/actions.py
@@ -82,26 +82,31 @@ def search(context: Context, data_dict: DataDict):
     for plugin in PluginImplementations(ISearchFeature):
         plugin.before_query(query_dict)
 
+    # This is valid and a search schema exists for it
+    entity_type = query_dict["entity_type"]
+
     # Permission labels
-    if labels := _get_permission_labels(context):
-        perm_labels_filter_op = FilterOp(
-            field="permission_labels", op="in", value=labels
-        )
+    # TODO: where to put this?
+    if entity_type == "dataset":
+        if labels := _get_permission_labels(context):
+            perm_labels_filter_op = FilterOp(
+                field="permission_labels", op="in", value=labels
+            )
 
-        if filter_op := query_dict["filters"]:
-            if filter_op.op == "$and":
-                # Add the filter to the existing AND filters
-                filter_op.value.append(perm_labels_filter_op)
+            if filter_op := query_dict["filters"]:
+                if filter_op.op == "$and":
+                    # Add the filter to the existing AND filters
+                    filter_op.value.append(perm_labels_filter_op)
+                else:
+                    # Wrap existing filters and the perms one in an AND operation
+                    query_dict["filters"] = FilterOp(
+                        field=None, op="$and", value=[filter_op, perm_labels_filter_op]
+                    )
+                pass
             else:
-                # Wrap existing filters and the perms one in an AND operation
-                query_dict["filters"] = FilterOp(
-                    field=None, op="$and", value=[filter_op, perm_labels_filter_op]
-                )
-            pass
-        else:
-            query_dict["filters"] = perm_labels_filter_op
+                query_dict["filters"] = perm_labels_filter_op
 
-    search_schema = get_search_schema()
+    search_schema = get_search_schema(entity_type)
     query_dict["search_schema"] = search_schema
     search_provider = config["ckan.search.search_provider"]
 

--- a/ckanext/search/logic/actions.py
+++ b/ckanext/search/logic/actions.py
@@ -32,6 +32,12 @@ def search(context: Context, data_dict: DataDict):
     for plugin in PluginImplementations(ISearchFeature):
         additional_params_schema.update(plugin.search_query_schema())
 
+    # Allow search entity to add custom params
+    # TODO: what about core plugins
+    for plugin in PluginImplementations(ISearchEntity):
+        additional_params_schema.update(plugin.search_query_schema())
+
+
     # Any fields not in the default schema are moved to additional_params
     default_query_fields = schema.keys()
 

--- a/ckanext/search/logic/actions.py
+++ b/ckanext/search/logic/actions.py
@@ -5,15 +5,17 @@ from ckan.plugins import PluginImplementations
 from ckan.plugins.toolkit import (
     check_access,
     config,
+    get_or_bust,
     side_effect_free,
     navl_validate,
     ValidationError,
 )
 from ckan.types import Context, DataDict
-from ckanext.search.interfaces import ISearchProvider, ISearchFeature
+from ckanext.search.interfaces import ISearchProvider, ISearchFeature, ISearchEntity
 from ckanext.search.schema import get_search_schema
 from ckanext.search.logic.schema import default_search_query_schema
 from ckanext.search.filters import FilterOp
+from ckanext.search.index import _get_entity_plugins
 
 
 @side_effect_free
@@ -22,6 +24,8 @@ def search(context: Context, data_dict: DataDict):
     check_access("search", context, data_dict)
 
     schema = default_search_query_schema()
+
+    entity_type = get_or_bust(data_dict, "entity_type")
 
     additional_params_schema = {}
     # Allow search providers to add custom params
@@ -32,11 +36,10 @@ def search(context: Context, data_dict: DataDict):
     for plugin in PluginImplementations(ISearchFeature):
         additional_params_schema.update(plugin.search_query_schema())
 
-    # Allow search entity to add custom params
-    # TODO: what about core plugins
-    for plugin in PluginImplementations(ISearchEntity):
-        additional_params_schema.update(plugin.search_query_schema())
-
+    # Allow search entities to add custom params
+    for plugin in _get_entity_plugins():
+        if plugin.entity_type() == entity_type:
+            additional_params_schema.update(plugin.search_query_schema())
 
     # Any fields not in the default schema are moved to additional_params
     default_query_fields = schema.keys()
@@ -73,6 +76,11 @@ def search(context: Context, data_dict: DataDict):
     # Allow search extensions to modify the query params
     for plugin in PluginImplementations(ISearchFeature):
         plugin.before_query(query_dict, context)
+
+    # Allow search entities to modify the query params
+    for plugin in _get_entity_plugins():
+        if plugin.entity_type() == entity_type:
+            plugin.before_query(query_dict, context)
 
     # This is valid and a search schema exists for it
     entity_type = query_dict["entity_type"]

--- a/ckanext/search/logic/schema.py
+++ b/ckanext/search/logic/schema.py
@@ -12,32 +12,49 @@ from ckan.types import (
     Context,
 )
 
-from ckan.plugins.toolkit import ValidationError
+from ckan.plugins.toolkit import ValidationError, Invalid, missing
 from ckanext.search.filters import parse_query_filters
-from ckanext.search.schema import get_search_schema
+from ckanext.search.schema import get_search_schema, get_search_schemas
 
 
-def query_filters_validator(search_schema) -> Validator:
+def query_filters_validator(
+    key: FlattenKey,
+    data: FlattenDataDict,
+    errors: FlattenErrorDict,
+    context: Context,
+) -> Any:
 
-    def callable(
-        key: FlattenKey,
-        data: FlattenDataDict,
-        errors: FlattenErrorDict,
-        context: Context,
-    ) -> Any:
+    value = data.get(key)
 
-        value = data.get(key)
+    entity_type = data.get(("entity_type",))
+    if entity_type is missing:
+        errors[key] = ["Could not find schema, no entity type provided"]
+        return
 
-        try:
-            data[key] = parse_query_filters(value, search_schema)
-        except ValidationError as e:
-            errors[key] = e.error_dict["filters"]
+    search_schema = get_search_schema(entity_type)
 
-    return callable
+    if not search_schema:
+        errors[key] = [f"Could not find schema for entity type: {entity_type}"]
+        return
+
+    try:
+        # TODO: typing
+        data[key] = parse_query_filters(value, search_schema)
+    except ValidationError as e:
+        errors[key] = e.error_dict["filters"]
+
+
+def known_entity_type(value):
+
+    if value not in get_search_schemas().keys():
+        raise Invalid(f"Unknown entity type: {value}")
+
+    return value
 
 
 @validator_args
 def default_search_query_schema(
+    not_empty: Validator,
     ignore_missing: Validator,
     ignore_empty: Validator,
     remove_whitespace: Validator,
@@ -53,6 +70,7 @@ def default_search_query_schema(
 
     return {
         "q": [ignore_missing, unicode_safe],
+        "entity_type": [not_empty, known_entity_type, unicode_safe],
         "limit": [
             default(10),
             natural_number_validator,
@@ -64,7 +82,7 @@ def default_search_query_schema(
         "filters": [
             ignore_missing,
             convert_to_json_if_string,
-            query_filters_validator(get_search_schema()),
+            query_filters_validator,
         ],
         "lang": [ignore_missing],
     }

--- a/ckanext/search/plugin.py
+++ b/ckanext/search/plugin.py
@@ -3,14 +3,30 @@ import ckan.plugins.toolkit as toolkit
 
 from ckanext.search import cli
 from ckanext.search.logic import actions, auth
+import ckanext.search.schema as search_schema
 
 # TODO: All this whole plugin will eventually live in CKAN core
 
 
 class SearchPlugin(plugins.SingletonPlugin):
+    plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IClick)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)
+
+    # IConfigurer
+    def update_config(self, config):
+
+        # TODO: this will be done in core (config/environment.py) for the
+        # core entities
+        search_schema.reset_search_schemas()
+        search_schema.register_search_schema(
+            "dataset", search_schema.DEFAULT_DATASET_SEARCH_SCHEMA
+        )
+        search_schema.register_search_schema(
+            "organization",
+            search_schema.DEFAULT_ORGANIZATION_SEARCH_SCHEMA,
+        )
 
     # IActions
     def get_actions(self):

--- a/ckanext/search/providers/es.py
+++ b/ckanext/search/providers/es.py
@@ -104,6 +104,7 @@ class ElasticSearchProvider(SingletonPlugin):
 
     def search_query(
         self,
+        entity_type: str,
         q: str,
         filters: FilterOp,
         sort: list[list[str]],
@@ -119,6 +120,10 @@ class ElasticSearchProvider(SingletonPlugin):
 
         es_params = {"size": limit, "from": start}
 
+        # TODO: If we switch to one index per entity this won't be necessary
+        # (we'll just pass the relevant `index` param to client.search())
+        entity_type_dsl = {"term": {"entity_type": entity_type}}
+
         # Translate q param to ES Query DSL
         if q and q in ("*", "*:*"):
             q_dsl = {"match_all": {}}
@@ -131,13 +136,15 @@ class ElasticSearchProvider(SingletonPlugin):
         filters_dsl = self._filterop_to_es_query(filters, search_schema)
 
         if q_dsl and filters_dsl:
-            es_params["query"] = {"bool": {"must": [q_dsl, filters_dsl]}}
+            es_params["query"] = {
+                "bool": {"must": [entity_type_dsl, q_dsl, filters_dsl]}
+            }
         elif q_dsl:
-            es_params["query"] = q_dsl
+            es_params["query"] = {"bool": {"must": [entity_type_dsl, q_dsl]}}
         elif filters_dsl:
-            es_params["query"] = filters_dsl
+            es_params["query"] = {"bool": {"must": [entity_type_dsl, filters_dsl]}}
         else:
-            es_params["query"] = {"match_all": {}}
+            es_params["query"] = entity_type_dsl
 
         client = self.get_client()
 

--- a/ckanext/search/providers/es.py
+++ b/ckanext/search/providers/es.py
@@ -33,7 +33,7 @@ class ElasticSearchProvider(SingletonPlugin):
     # ISearchProvider
 
     def initialize_search_provider(
-        self, search_schema: SearchSchema, clear: bool
+        self, search_schemas: dict[str, SearchSchema], clear: bool
     ) -> None:
 
         client = self.get_client()
@@ -56,8 +56,13 @@ class ElasticSearchProvider(SingletonPlugin):
             "bool": "boolean",
         }
 
+        # TODO: For now we combine all fields in all schemas and create just one
+        # index. We probably want to create one core per entity to keep schemas
+        # separate, but then we need to consider cross-entity searches
+        combined_search_schema = merge_search_schemas(list(search_schemas.values()))
+
         mapping = {"properties": {}}
-        for field_name, field in search_schema.get("fields", {}).items():
+        for field_name, field in combined_search_schema.get("fields", {}).items():
 
             field_type = field.pop("type")
 
@@ -258,3 +263,33 @@ class ElasticSearchProvider(SingletonPlugin):
         )
 
         return self._client
+
+
+def merge_search_schemas(schemas: list[SearchSchema]) -> SearchSchema:
+    """
+    Merge multiple search schemas into one, ensuring fields with the same name
+    have identical properties.
+
+    Raises ValueError if conflicting field definitions are found.
+    """
+    if not schemas:
+        return {"version": 1, "fields": {}}
+
+    # Use the version from the first schema
+    result: SearchSchema = {"version": schemas[0].get("version", 1), "fields": {}}
+
+    for schema in schemas:
+        for field_name, field_props in schema.get("fields", {}).items():
+            if field_name in result["fields"]:
+                # Check if the new field definition matches the existing one
+                existing_props = result["fields"][field_name]
+
+                if field_props != existing_props:
+                    raise ValueError(
+                        f"Conflicting definitions for field '{field_name}': "
+                        f"{existing_props} vs {field_props}"
+                    )
+            else:
+                result["fields"][field_name] = field_props
+
+    return result

--- a/ckanext/search/providers/solr.py
+++ b/ckanext/search/providers/solr.py
@@ -179,11 +179,15 @@ class SolrSearchProvider(SingletonPlugin):
     # ISearchProvider
 
     def initialize_search_provider(
-        self, search_schema: SearchSchema, clear: bool
+        self, search_schemas: dict[str, SearchSchema], clear: bool
     ) -> None:
 
         admin_client = self.get_admin_client()
-        # TODO: Should be create the ckan core here?
+
+        # TODO: For now we combine all fields in all schemas and create just one
+        # core. We probably want to create one core per entity to keep schemas
+        # separate, but then we need to consider cross-entity searches
+        combined_search_schema = merge_search_schemas(list(search_schemas.values()))
 
         if not admin_client.get_core():
             resp = admin_client.create_core()
@@ -215,7 +219,7 @@ class SolrSearchProvider(SingletonPlugin):
             "date": "pdate",
         }
 
-        for field_name, field in search_schema.get("fields", {}).items():
+        for field_name, field in combined_search_schema.get("fields", {}).items():
 
             field_type = field.pop("type")
             if admin_client.get_field(field_name):
@@ -535,3 +539,33 @@ def solr_literal(t: str) -> str:
     and permission labels.
     """
     return '"' + t.replace('"', "") + '"'
+
+
+def merge_search_schemas(schemas: list[SearchSchema]) -> SearchSchema:
+    """
+    Merge multiple search schemas into one, ensuring fields with the same name
+    have identical properties.
+
+    Raises ValueError if conflicting field definitions are found.
+    """
+    if not schemas:
+        return {"version": 1, "fields": {}}
+
+    # Use the version from the first schema
+    result: SearchSchema = {"version": schemas[0].get("version", 1), "fields": {}}
+
+    for schema in schemas:
+        for field_name, field_props in schema.get("fields", {}).items():
+            if field_name in result["fields"]:
+                # Check if the new field definition matches the existing one
+                existing_props = result["fields"][field_name]
+
+                if field_props != existing_props:
+                    raise ValueError(
+                        f"Conflicting definitions for field '{field_name}': "
+                        f"{existing_props} vs {field_props}"
+                    )
+            else:
+                result["fields"][field_name] = field_props
+
+    return result

--- a/ckanext/search/providers/solr.py
+++ b/ckanext/search/providers/solr.py
@@ -318,6 +318,7 @@ class SolrSearchProvider(SingletonPlugin):
 
     def search_query(
         self,
+        entity_type: str,
         q: str,
         filters: FilterOp,
         sort: list[list[str]],
@@ -349,6 +350,9 @@ class SolrSearchProvider(SingletonPlugin):
         }
 
         solr_params["fq"] = self._filterop_to_solr_fq(filters, search_schema)
+        # TODO: If we switch to one core per entity this won't be necessary
+        # (we'll just search the relevant core in client.search())
+        solr_params["fq"].append(f"entity_type:{entity_type}")
 
         # TODO: perm labels for arbitrary entities
 

--- a/ckanext/search/schema.py
+++ b/ckanext/search/schema.py
@@ -1,36 +1,5 @@
-from typing import Optional
 from ckan.plugins import PluginImplementations
 from ckanext.search.interfaces import SearchSchema, ISearchProvider, ISearchFeature
-
-
-def merge_search_schemas(schemas: list[SearchSchema]) -> SearchSchema:
-    """
-    Merge multiple search schemas into one, ensuring fields with the same name
-    have identical properties.
-
-    Raises ValueError if conflicting field definitions are found.
-    """
-    if not schemas:
-        return {"version": 1, "fields": {}}
-
-    # Use the version from the first schema
-    result: SearchSchema = {"version": schemas[0].get("version", 1), "fields": {}}
-
-    for schema in schemas:
-        for field_name, field_props in schema.get("fields", {}).items():
-            if field_name in result["fields"]:
-                # Check if the new field definition matches the existing one
-                existing_props = result["fields"][field_name]
-
-                if field_props != existing_props:
-                    raise ValueError(
-                        f"Conflicting definitions for field '{field_name}': "
-                        f"{existing_props} vs {field_props}"
-                    )
-            else:
-                result["fields"][field_name] = field_props
-
-    return result
 
 
 DEFAULT_DATASET_SEARCH_SCHEMA: SearchSchema = {
@@ -77,20 +46,41 @@ DEFAULT_ORGANIZATION_SEARCH_SCHEMA: SearchSchema = {
 }
 
 
-def get_search_schema(entity_type: Optional[str] = None) -> SearchSchema:
-    search_schemas = [
-        DEFAULT_DATASET_SEARCH_SCHEMA,
-        DEFAULT_ORGANIZATION_SEARCH_SCHEMA,
-    ]
+_search_schemas: dict[str, SearchSchema] = {}
+
+
+def reset_search_schemas() -> None:
+
+    global _search_schemas
+
+    _search_schemas = {}
+
+
+def register_search_schema(name: str, schema: SearchSchema) -> None:
+
+    global _search_schemas
+
+    _search_schemas[name] = schema
+
+
+def get_search_schema(entity_type: str) -> SearchSchema:
+
+    global _search_schemas
 
     # TODO: return custom entities
     # TODO: include fields from ISearchFeature plugins (per entity?)
-    if entity_type == "dataset":
-        return DEFAULT_DATASET_SEARCH_SCHEMA
-    elif entity_type == "organization":
-        return DEFAULT_ORGANIZATION_SEARCH_SCHEMA
-    else:
-        return merge_search_schemas(search_schemas)
+    if entity_type not in _search_schemas:
+        # TODO: custom exception
+        raise ValueError(f"Unknown search entity type: {entity_type}")
+
+    return _search_schemas[entity_type]
+
+
+def get_search_schemas() -> dict[str, SearchSchema]:
+
+    global _search_schemas
+
+    return _search_schemas
 
 
 def init_schema(provider_id: str | None = None):
@@ -101,7 +91,7 @@ def init_schema(provider_id: str | None = None):
 
     # TODO: validate with navl
 
-    combined_search_schema = get_search_schema()
+    search_schemas = get_search_schemas()
 
     provider_ids = []
     # Search providers set things up first
@@ -118,11 +108,11 @@ def init_schema(provider_id: str | None = None):
         provider_ids = [p.id for p in plugins]
 
     for plugin in plugins:
-        plugin.initialize_search_provider(combined_search_schema, clear=False)
+        plugin.initialize_search_provider(search_schemas, clear=False)
 
     # Search feature plugins can add things later
     for plugin in PluginImplementations(ISearchFeature):
         if any(
             provider_id in plugin.supported_providers() for provider_id in provider_ids
         ):
-            plugin.initialize_search_provider(combined_search_schema, clear=False)
+            plugin.initialize_search_provider(search_schemas, clear=False)

--- a/ckanext/search/schema.py
+++ b/ckanext/search/schema.py
@@ -16,6 +16,7 @@ DEFAULT_DATASET_SEARCH_SCHEMA: SearchSchema = {
         "groups": {"type": "string", "multiple": True},
         "owner_org": {"type": "string"},
         "private": {"type": "bool"},
+        "state": {"type": "string"},
         "metadata_created": {"type": "date"},
         "metadata_modified": {"type": "date"},
         "permission_labels": {"type": "string", "multiple": True},

--- a/ckanext/search/search_plugins.py
+++ b/ckanext/search/search_plugins.py
@@ -6,7 +6,7 @@ from geomet import wkt
 
 from ckan.plugins import SingletonPlugin, implements
 from ckan.plugins.toolkit import Invalid, get_validator, config
-from ckan.types import Schema
+from ckan.types import Schema, Context
 from ckanext.search.interfaces import ISearchFeature, SearchSchema
 
 from ckanext.search.providers.solr import SolrSchema
@@ -159,7 +159,7 @@ class SpatialSearch(SingletonPlugin):
 
         return search_query_schema
 
-    def before_query(self, query_params: dict[str, Any]) -> dict[str, Any]:
+    def before_query(self, query_params: dict[str, Any], context: Context) -> dict[str, Any]:
 
         if bbox := query_params["additional_params"].get("bbox"):
 

--- a/ckanext/search/tests/conftest.py
+++ b/ckanext/search/tests/conftest.py
@@ -16,7 +16,7 @@ def clean_search_index():
 
 class MockSearchFeature:
 
-    def before_query(self, query_dict):
+    def before_query(self, query_dict, context):
         pass
 
     def after_query(self, query_results, query_dict):

--- a/ckanext/search/tests/factories.py
+++ b/ckanext/search/tests/factories.py
@@ -1,8 +1,11 @@
+import json
+
 from ckan import model
+from ckan.lib.navl.dictization_functions import MissingNullEncoder
 
 from ckan.tests import factories as core_factories
 
-from ckanext.search import index
+from ckanext.search.index import rebuild_index
 
 
 class CKANIndexedOnlyFactory(core_factories.CKANFactory):
@@ -23,8 +26,8 @@ class CKANIndexedOnlyFactory(core_factories.CKANFactory):
     def _api_postprocess_result(cls, result):
         """Modify result before returning it to the consumer."""
 
-        if cls.indexer:
-            cls.indexer(result)
+        if cls.entity_type:
+            rebuild_index(cls.entity_type, ids=[result["id"]])
 
         model.Session.rollback()
 
@@ -33,9 +36,9 @@ class CKANIndexedOnlyFactory(core_factories.CKANFactory):
 
 class IndexedDataset(core_factories.Dataset, CKANIndexedOnlyFactory):
 
-    indexer = index.index_dataset_dict
+    entity_type = "dataset"
 
 
 class IndexedOrganization(core_factories.Organization, CKANIndexedOnlyFactory):
 
-    indexer = index.index_organization_dict
+    entity_type = "organization"

--- a/ckanext/search/tests/providers/test_query.py
+++ b/ckanext/search/tests/providers/test_query.py
@@ -31,7 +31,7 @@ def test_search_dataset_combined_field(field_name, field_value):
 
     dataset = factories.IndexedDataset(**{field_name: field_value})
 
-    result = search(q="walrus")
+    result = search(entity_type="dataset", q="walrus")
 
     assert result["count"] == 1
     assert result["results"][0]["id"] == dataset["id"]
@@ -55,7 +55,7 @@ def test_search_organization_combined_field(field_name, field_value):
 
     organization = factories.IndexedOrganization(**{field_name: field_value})
 
-    result = search(q="walrus")
+    result = search(entity_type="organization", q="walrus")
 
     assert result["count"] == 1
     assert result["results"][0]["id"] == organization["id"]

--- a/ckanext/search/tests/providers/test_query_filters.py
+++ b/ckanext/search/tests/providers/test_query_filters.py
@@ -140,7 +140,7 @@ def index_for_filters_tests():
 )
 def test_search_filters(filters, names):
 
-    result = search(q="*", filters=filters)
+    result = search(entity_type="dataset", q="*", filters=filters)
 
     assert result["count"] == len(names)
     if names:

--- a/ckanext/search/tests/test_action.py
+++ b/ckanext/search/tests/test_action.py
@@ -30,7 +30,13 @@ def test_standard_params(mock_search_plugins):
     assert query_params["start"] == 10
     assert query_params["sort"] == ["title asc"]
     assert query_params["filters"] == FilterOp(
-        field="entity_type", op="eq", value="dataset"
+        field=None,
+        op="$and",
+        value=[
+            FilterOp(field="entity_type", op="eq", value="dataset"),
+            FilterOp(field="private", op="eq", value=False),
+            FilterOp(field="state", op="in", value=["active"]),
+        ],
     )
 
 
@@ -51,7 +57,13 @@ def test_standard_params_are_converted(mock_search_plugins):
     assert query_params["start"] == 10
     assert query_params["sort"] == ["title asc"]
     assert query_params["filters"] == FilterOp(
-        field="entity_type", op="eq", value="dataset"
+        field=None,
+        op="$and",
+        value=[
+            FilterOp(field="entity_type", op="eq", value="dataset"),
+            FilterOp(field="private", op="eq", value=False),
+            FilterOp(field="state", op="in", value=["active"]),
+        ],
     )
 
 

--- a/ckanext/search/tests/test_action.py
+++ b/ckanext/search/tests/test_action.py
@@ -16,6 +16,7 @@ pytestmark = [
 def test_standard_params(mock_search_plugins):
     helpers.call_action(
         "search",
+        entity_type="dataset",
         q="cats",
         limit=10,
         start=10,
@@ -36,6 +37,7 @@ def test_standard_params(mock_search_plugins):
 def test_standard_params_are_converted(mock_search_plugins):
     helpers.call_action(
         "search",
+        entity_type="dataset",
         q="cats",
         limit="10",
         start="10",
@@ -58,6 +60,7 @@ def test_standard_params_are_validated(mock_search_plugins):
     with pytest.raises(toolkit.ValidationError) as exc_info:
         helpers.call_action(
             "search",
+            entity_type="dataset",
             q="cats",
             limit="a",
             start="b",
@@ -78,6 +81,7 @@ def test_standard_params_are_validated(mock_search_plugins):
 def test_provider_params(mock_search_plugins):
     helpers.call_action(
         "search",
+        entity_type="dataset",
         q="cats",
         df="title",
         qf="title^4.0 description^2.0",
@@ -92,6 +96,7 @@ def test_provider_params(mock_search_plugins):
 def test_feature_params(mock_search_plugins):
     helpers.call_action(
         "search",
+        entity_type="dataset",
         q="cats",
         custom_param="hi",
     )
@@ -106,6 +111,7 @@ def test_unknown_params_fail(mock_search_plugins):
     with pytest.raises(toolkit.ValidationError) as exc_info:
         helpers.call_action(
             "search",
+            entity_type="dataset",
             q="cats",
             not_="a",
             known="b",


### PR DESCRIPTION
* The `search` action only works against a provided `entity_type`, not across all entities
* Pass separate entity schemas to providers during initialization (ES and Solr still combine them in one single index/core but that can be split in the future)
* New `ISearchEntity` interface, used to encapsulate all search logic of a particular entity like dataset, org, custom, etc: schema, search query schema, transforming search data, getting ids...
* Added core plugins for datasets and organizations